### PR TITLE
Change Client log to io.Writer to allow more diversity in logging

### DIFF
--- a/types.go
+++ b/types.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"time"
+	"io"
 )
 
 const (
@@ -82,7 +83,7 @@ type (
 		ClientID string
 		Secret   string
 		APIBase  string
-		LogFile  string // If user set log file name all requests will be logged there
+		Log  	 io.Writer // If user set log file name all requests will be logged there
 		Token    *TokenResponse
 	}
 


### PR DESCRIPTION
This allows higher control by the end user to setup logging how they wish such as logging to terminal when learning and starting to use this package, or passing the logs over the wire etc. 

**CHANGE: Renamed 'SetLogFile' to 'SetLog' and changed the parameter from a string to io.Writer
CHANGE: Changed logFile name and type to name Log of type io.Writer
CHANGE: func log of client now uses new log object.**
