### PR TITLE
Fix README redirect url index

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ description := "Description for this payment"
 paymentResult, err := c.CreateDirectPaypalPayment(amount, redirectURI, cancelURI, description)
 
 // If paymentResult.ID is not empty and paymentResult.Links is also
-// we can redirect user to approval page (paymentResult.Links[0]).
+// we can redirect user to approval page (paymentResult.Links[1]).
 // After approval user will be redirected to return_url from Request with PaymentID
 ```
 


### PR DESCRIPTION
Redirect should be to paymentResult.Links[1] as this index corresponds to the approval_url for customers to approve payment.

As shown in Paypal docs here: 
https://developer.paypal.com/docs/integration/web/accept-paypal-payment/
