### PR TITLE
Fixed panic on logging requests without body (GET)

### DIFF
--- a/client.go
+++ b/client.go
@@ -135,8 +135,6 @@ func (c *Client) NewRequest(method, url string, payload interface{}) (*http.Requ
 func (c *Client) log(r *http.Request, resp *http.Response) {
 	if c.Log != nil {
 		reqDump := fmt.Sprintf("%s %s. Data: %s", r.Method, r.URL.String(), r.Form.Encode())
-		dump, _ := ioutil.ReadAll(r.Body)
-		fmt.Println(string(dump))
 		respDump, _ := httputil.DumpResponse(resp, true)
 
 		c.Log.Write([]byte("Request: " + reqDump + "\nResponse: " + string(respDump) + "\n\n"))


### PR DESCRIPTION
1. Setup client
2. Enable logging
3. Send GET request (e.g. GetPayment)

```go
client, err := paypalsdk.NewClient("",  "", paypalsdk.APIBaseSandBox)
client.SetLog(os.Stdout)
client.GetPayment("")
```

