### PR TITLE
change type of Item.Amount from string to int to get it working with …

### DIFF
--- a/types.go
+++ b/types.go
@@ -193,7 +193,7 @@ type (
 
 	// Item struct
 	Item struct {
-		Quantity    string `json:"quantity"`
+		Quantity    int    `json:"quantity"`
 		Name        string `json:"name"`
 		Price       string `json:"price"`
 		Currency    string `json:"currency"`

--- a/types_test.go
+++ b/types_test.go
@@ -36,7 +36,7 @@ func TestTypeItem(t *testing.T) {
     "name":"Item",
     "price":"22.99",
     "currency":"GBP",
-    "quantity":"1"
+    "quantity":1
 }`
 
 	i := &Item{}
@@ -48,7 +48,7 @@ func TestTypeItem(t *testing.T) {
 	if i.Name != "Item" ||
 		i.Price != "22.99" ||
 		i.Currency != "GBP" ||
-		i.Quantity != "1" {
+		i.Quantity != 1 {
 		t.Errorf("Item decoded result is incorrect, Given: %v", i)
 	}
 }


### PR DESCRIPTION
…the newest PayPal API

Sadly I didn't find any source for this change, but I discovered the problem today while developing with this SDK.