### PR TITLE
Added the external_customer_id property

### DIFF
--- a/types.go
+++ b/types.go
@@ -119,7 +119,7 @@ type (
 	CreditCard struct {
 		ID                 string   `json:"id,omitempty"`
 		PayerID            string   `json:"payer_id,omitempty"`
-		ExternalCustomerId string   `json:"external_customer_id,omitempty"`
+		ExternalCustomerID string   `json:"external_customer_id,omitempty"`
 		Number             string   `json:"number"`
 		Type               string   `json:"type"`
 		ExpireMonth        string   `json:"expire_month"`

--- a/types.go
+++ b/types.go
@@ -117,18 +117,19 @@ type (
 
 	// CreditCard struct
 	CreditCard struct {
-		ID             string   `json:"id,omitempty"`
-		PayerID        string   `json:"payer_id,omitempty"`
-		Number         string   `json:"number"`
-		Type           string   `json:"type"`
-		ExpireMonth    string   `json:"expire_month"`
-		ExpireYear     string   `json:"expire_year"`
-		CVV2           string   `json:"cvv2,omitempty"`
-		FirstName      string   `json:"first_name,omitempty"`
-		LastName       string   `json:"last_name,omitempty"`
-		BillingAddress *Address `json:"billing_address,omitempty"`
-		State          string   `json:"state,omitempty"`
-		ValidUntil     string   `json:"valid_until,omitempty"`
+		ID                 string   `json:"id,omitempty"`
+		PayerID            string   `json:"payer_id,omitempty"`
+		ExternalCustomerId string   `json:"external_customer_id,omitempty"`
+		Number             string   `json:"number"`
+		Type               string   `json:"type"`
+		ExpireMonth        string   `json:"expire_month"`
+		ExpireYear         string   `json:"expire_year"`
+		CVV2               string   `json:"cvv2,omitempty"`
+		FirstName          string   `json:"first_name,omitempty"`
+		LastName           string   `json:"last_name,omitempty"`
+		BillingAddress     *Address `json:"billing_address,omitempty"`
+		State              string   `json:"state,omitempty"`
+		ValidUntil         string   `json:"valid_until,omitempty"`
 	}
 
 	// CreditCards GET /v1/vault/credit-cards


### PR DESCRIPTION
The payer_id is being deprecated in favor of the external_customer_id property.

https://developer.paypal.com/docs/api/vault/#credit-card_create