### PR TITLE
Fix access token refresh

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
+	"time"
 )
 
 // NewClient returns new Client struct
@@ -45,6 +46,7 @@ func (c *Client) GetAccessToken() (*TokenResponse, error) {
 	// Set Token fur current Client
 	if t.Token != "" {
 		c.Token = &t
+		c.tokenExpiresAt = time.Now().Add(time.Duration(t.ExpiresIn) * time.Second)
 	}
 
 	return &t, err
@@ -55,6 +57,7 @@ func (c *Client) SetAccessToken(token string) error {
 	c.Token = &TokenResponse{
 		Token: token,
 	}
+	c.tokenExpiresAt = time.Unix(0, 0)
 
 	return nil
 }
@@ -124,7 +127,7 @@ func (c *Client) Send(req *http.Request, v interface{}) error {
 // client.Token will be updated when changed
 func (c *Client) SendWithAuth(req *http.Request, v interface{}) error {
 	if c.Token != nil {
-		if c.Token.ExpiresIn < RequestNewTokenBeforeExpiresIn {
+		if !c.tokenExpiresAt.IsZero() && time.Until(c.tokenExpiresAt) < RequestNewTokenBeforeExpiresIn {
 			// c.Token will be updated in GetAccessToken call
 			if _, err := c.GetAccessToken(); err != nil {
 				return err

--- a/client.go
+++ b/client.go
@@ -127,7 +127,7 @@ func (c *Client) Send(req *http.Request, v interface{}) error {
 // client.Token will be updated when changed
 func (c *Client) SendWithAuth(req *http.Request, v interface{}) error {
 	if c.Token != nil {
-		if !c.tokenExpiresAt.IsZero() && time.Until(c.tokenExpiresAt) < RequestNewTokenBeforeExpiresIn {
+		if !c.tokenExpiresAt.IsZero() && c.tokenExpiresAt.Sub(time.Now()) < RequestNewTokenBeforeExpiresIn {
 			// c.Token will be updated in GetAccessToken call
 			if _, err := c.GetAccessToken(); err != nil {
 				return err

--- a/types.go
+++ b/types.go
@@ -15,7 +15,7 @@ const (
 	APIBaseLive = "https://api.paypal.com"
 
 	// RequestNewTokenBeforeExpiresIn is used by SendWithAuth and try to get new Token when it's about to expire
-	RequestNewTokenBeforeExpiresIn = 60
+	RequestNewTokenBeforeExpiresIn = time.Duration(60) * time.Second
 )
 
 // Possible values for `no_shipping` in InputFields
@@ -107,12 +107,13 @@ type (
 
 	// Client represents a Paypal REST API Client
 	Client struct {
-		client   *http.Client
-		ClientID string
-		Secret   string
-		APIBase  string
-		Log      io.Writer // If user set log file name all requests will be logged there
-		Token    *TokenResponse
+		client         *http.Client
+		ClientID       string
+		Secret         string
+		APIBase        string
+		Log            io.Writer // If user set log file name all requests will be logged there
+		Token          *TokenResponse
+		tokenExpiresAt time.Time
 	}
 
 	// CreditCard struct


### PR DESCRIPTION
`expires_in` returned from PayPal is the number of seconds the access token is valid for. The previous comparison was checking if `ExpiresIn` was less than `60`. Since both values never change, this would only be true if the original value was less than `60` (which it likely never is). 

This change determines the expiration time, and checks if the time remaining is less than the constant `RequestNewTokenBeforeExpiresIn` (60 seconds). If so, an access token refresh is performed.