### PR TITLE
Add SetHTTPClient function to *Client

### DIFF
--- a/client.go
+++ b/client.go
@@ -19,7 +19,7 @@ func NewClient(clientID string, secret string, APIBase string) (*Client, error) 
 	}
 
 	return &Client{
-		client:   &http.Client{},
+		Client:   &http.Client{},
 		ClientID: clientID,
 		Secret:   secret,
 		APIBase:  APIBase,
@@ -49,6 +49,13 @@ func (c *Client) GetAccessToken() (*TokenResponse, error) {
 
 	return &t, err
 }
+
+// SetHTTPClient sets *http.Client to current client
+func (c *Client) SetHTTPClient(client *http.Client) error {
+	c.Client = client
+	return nil
+}
+
 
 // SetAccessToken sets saved token to current client
 func (c *Client) SetAccessToken(token string) error {
@@ -85,7 +92,7 @@ func (c *Client) Send(req *http.Request, v interface{}) error {
 		req.Header.Set("Content-type", "application/json")
 	}
 
-	resp, err = c.client.Do(req)
+	resp, err = c.Client.Do(req)
 	c.log(req, resp)
 
 	if err != nil {

--- a/types.go
+++ b/types.go
@@ -107,7 +107,7 @@ type (
 
 	// Client represents a Paypal REST API Client
 	Client struct {
-		client   *http.Client
+		Client   *http.Client
 		ClientID string
 		Secret   string
 		APIBase  string


### PR DESCRIPTION
When we use GoogleAppEngine/Go environment, We should replace http.Client to urlfetch.Client.
https://cloud.google.com/appengine/docs/standard/go/urlfetch/reference

This changes works fine in my environment!
