### PR TITLE
Added Details Struct and added Details Member to Amount struct 

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -3,8 +3,6 @@
 package paypalsdk
 
 import (
-	"encoding/json"
-	"fmt"
 	"os"
 	"testing"
 )
@@ -156,7 +154,7 @@ func TestVoidOrder(t *testing.T) {
 
 func TestCreateDirectPaypalPayment(t *testing.T) {
 	c, _ := NewClient(testClientID, testSecret, APIBaseSandBox)
-	//c.SetLog(os.Stdout)
+	c.SetLog(os.Stdout)
 	c.GetAccessToken()
 
 	amount := Amount{
@@ -214,16 +212,14 @@ func TestCreatePayment(t *testing.T) {
 			},
 		}},
 		RedirectURLs: &RedirectURLs{
-			ReturnURL: "http://localhost:9000/gb/checkout/payment",
-			CancelURL: "http://localhost:9000/gb/checkout/summary",
+			ReturnURL: "http://..",
+			CancelURL: "http://..",
 		},
 	}
 	pr, err := c.CreatePayment(p)
 	if err != nil {
 		t.Errorf("Error creating payment.")
 	}
-	pmEnc, _ := json.Marshal(pr)
-	fmt.Printf("pmEnc: %s", pmEnc)
 }
 
 func TestGetPayment(t *testing.T) {

--- a/types.go
+++ b/types.go
@@ -72,8 +72,9 @@ type (
 
 	// Amount struct
 	Amount struct {
-		Currency string `json:"currency"`
-		Total    string `json:"total"`
+		Currency string  `json:"currency"`
+		Total    string  `json:"total"`
+		Details  Details `json:"details,omitempty"`
 	}
 
 	// AmountPayout struct
@@ -208,6 +209,17 @@ type (
 	Currency struct {
 		Currency string `json:"currency,omitempty"`
 		Value    string `json:"value,omitempty"`
+	}
+
+	// Details structure used in Amount structures as optional value
+	Details struct {
+		Subtotal         string `json:"subtotal,omitempty"`
+		Shipping         string `json:"shipping,omitempty"`
+		Tax              string `json:"tax,omitempty"`
+		HandlingFee      string `json:"handling_fee,omitempty"`
+		ShippingDiscount string `json:"shipping_discount,omitempty"`
+		Insurance        string `json:"insurance,omitempty"`
+		GiftWrap         string `json:"gift_wrap,omitempty"`
 	}
 
 	// ErrorResponse https://developer.paypal.com/docs/api/errors/


### PR DESCRIPTION
In using this module in our project at we encountered a situation where we needed to create payments that contained multiple products with different shipping costs for each. After studying the paypal documentation, the solution was to add the products as Items in the transaction and add the total shipping cost into the Details of the Amount object attached to the Transaction object. The module lacked that struct so i added it. I also added a example using this in the integration_test. In testing adding multiple transactions failed with paypal stating multiple transactions are not allowed.

Daniel @Blendtrix Development Team