### PR TITLE
Add sender_batch_id to payout SenderBatchHeader object

### DIFF
--- a/types.go
+++ b/types.go
@@ -437,7 +437,8 @@ type (
 
 	// SenderBatchHeader struct
 	SenderBatchHeader struct {
-		EmailSubject string `json:"email_subject"`
+		EmailSubject  string `json:"email_subject"`
+		SenderBatchID string `json:"sender_batch_id,omitempty"`
 	}
 
 	// ShippingAddress struct


### PR DESCRIPTION
As per https://developer.paypal.com/docs/api/payments.payouts-batch#definition-sender_batch_header when sending through Payout requests, a batch ID can be specified to ensure that duplicate batch requests aren't processed.

I haven't added to the Payout integration test, because I'm not sure of the best way of getting around this deduping behaviour - I don't want integration tests to fail because previous or other people's runs have used the same ID.