### PR TITLE
Set correct "zero time" in SetAccessToken

### DIFF
--- a/client.go
+++ b/client.go
@@ -37,11 +37,10 @@ func (c *Client) GetAccessToken() (*TokenResponse, error) {
 		return &TokenResponse{}, err
 	}
 
-	req.SetBasicAuth(c.ClientID, c.Secret)
 	req.Header.Set("Content-type", "application/x-www-form-urlencoded")
 
 	t := TokenResponse{}
-	err = c.Send(req, &t)
+	err = c.SendWithBasicAuth(req, &t)
 
 	// Set Token fur current Client
 	if t.Token != "" {
@@ -142,6 +141,13 @@ func (c *Client) SendWithAuth(req *http.Request, v interface{}) error {
 
 		req.Header.Set("Authorization", "Bearer "+c.Token.Token)
 	}
+
+	return c.Send(req, v)
+}
+
+// SendWithBasicAuth makes a request to the API using clientID:secret basic auth
+func (c *Client) SendWithBasicAuth(req *http.Request, v interface{}) error {
+	req.SetBasicAuth(c.ClientID, c.Secret)
 
 	return c.Send(req, v)
 }

--- a/client.go
+++ b/client.go
@@ -63,7 +63,7 @@ func (c *Client) SetAccessToken(token string) error {
 	c.Token = &TokenResponse{
 		Token: token,
 	}
-	c.tokenExpiresAt = time.Unix(0, 0)
+	c.tokenExpiresAt = time.Time{}
 
 	return nil
 }

--- a/identity.go
+++ b/identity.go
@@ -3,25 +3,28 @@ package paypalsdk
 import (
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 )
 
 // GrantNewAccessTokenFromAuthCode - Use this call to grant a new access token, using the previously obtained authorization code.
 // Endpoint: POST /v1/identity/openidconnect/tokenservice
 func (c *Client) GrantNewAccessTokenFromAuthCode(code string, redirectURI string) (*TokenResponse, error) {
-	type request struct {
-		GrantType   string `json:"grant_type"`
-		Code        string `json:"code"`
-		RedirectURI string `json:"redirect_uri"`
-	}
-
 	token := &TokenResponse{}
 
-	req, err := c.NewRequest("POST", fmt.Sprintf("%s%s", c.APIBase, "/v1/identity/openidconnect/tokenservice"), request{GrantType: "authorization_code", Code: code, RedirectURI: redirectURI})
+	q := url.Values{}
+	q.Set("grant_type", "authorization_code")
+	q.Set("code", code)
+	q.Set("redirect_uri", redirectURI)
+
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s%s", c.APIBase, "/v1/identity/openidconnect/tokenservice"), strings.NewReader(q.Encode()))
 	if err != nil {
 		return token, err
 	}
 
-	err = c.SendWithAuth(req, token)
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	err = c.SendWithBasicAuth(req, token)
 	if err != nil {
 		return token, err
 	}

--- a/types.go
+++ b/types.go
@@ -1,6 +1,7 @@
 package paypalsdk
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -454,12 +455,14 @@ type (
 		Phone         string `json:"phone,omitempty"`
 	}
 
+	expirationTime int64
+
 	// TokenResponse is for API response for the /oauth2/token endpoint
 	TokenResponse struct {
-		RefreshToken string `json:"refresh_token"`
-		Token        string `json:"access_token"`
-		Type         string `json:"token_type"`
-		ExpiresIn    int64  `json:"expires_in"`
+		RefreshToken string         `json:"refresh_token"`
+		Token        string         `json:"access_token"`
+		Type         string         `json:"token_type"`
+		ExpiresIn    expirationTime `json:"expires_in"`
 	}
 
 	// Transaction struct
@@ -543,4 +546,18 @@ func (r *ErrorResponse) Error() string {
 func (t JSONTime) MarshalJSON() ([]byte, error) {
 	stamp := fmt.Sprintf(`"%s"`, time.Time(t).UTC().Format(time.RFC3339))
 	return []byte(stamp), nil
+}
+
+func (e *expirationTime) UnmarshalJSON(b []byte) error {
+	var n json.Number
+	err := json.Unmarshal(b, &n)
+	if err != nil {
+		return err
+	}
+	i, err := n.Int64()
+	if err != nil {
+		return err
+	}
+	*e = expirationTime(i)
+	return nil
 }

--- a/types.go
+++ b/types.go
@@ -483,14 +483,14 @@ type (
 		GivenName       string   `json:"given_name"`
 		FamilyName      string   `json:"family_name"`
 		Email           string   `json:"email"`
-		Verified        bool     `json:"verified,omitempty"`
+		Verified        bool     `json:"verified,omitempty,string"`
 		Gender          string   `json:"gender,omitempty"`
 		BirthDate       string   `json:"birthdate,omitempty"`
 		ZoneInfo        string   `json:"zoneinfo,omitempty"`
 		Locale          string   `json:"locale,omitempty"`
 		Phone           string   `json:"phone_number,omitempty"`
 		Address         *Address `json:"address,omitempty"`
-		VerifiedAccount bool     `json:"verified_account,omitempty"`
+		VerifiedAccount bool     `json:"verified_account,omitempty,string"`
 		AccountType     string   `json:"account_type,omitempty"`
 		AgeRange        string   `json:"age_range,omitempty"`
 		PayerID         string   `json:"payer_id,omitempty"`


### PR DESCRIPTION
Setting a custom token was broken since https://github.com/logpacker/PayPal-Go-SDK/pull/29. 

Since time.Unix(0, 0) is NOT a "zero time" in go it caused the [check at SendWithAuth function](https://github.com/logpacker/PayPal-Go-SDK/blob/master/client.go#L136) to never fail which lead to custom token always being replaced by a fresh token.