### PR TITLE
Set correct "zero time" in SetAccessToken

### DIFF
--- a/client.go
+++ b/client.go
@@ -63,7 +63,7 @@ func (c *Client) SetAccessToken(token string) error {
 	c.Token = &TokenResponse{
 		Token: token,
 	}
-	c.tokenExpiresAt = time.Unix(0, 0)
+	c.tokenExpiresAt = time.Time{}
 
 	return nil
 }


### PR DESCRIPTION
Setting a custom token was broken since https://github.com/logpacker/PayPal-Go-SDK/pull/29. 

Since time.Unix(0, 0) is NOT a "zero time" in go it caused the [check at SendWithAuth function](https://github.com/logpacker/PayPal-Go-SDK/blob/master/client.go#L136) to never fail which lead to custom token always being replaced by a fresh token.

P.S. opened a new PR to use correct branch in my fork.