### PR TITLE
Added method to get Billing Agreement details

### DIFF
--- a/billing.go
+++ b/billing.go
@@ -96,3 +96,20 @@ func (c *Client) ExecuteApprovedAgreement(token string) (*ExecuteAgreementRespon
 
 	return &e, err
 }
+
+// GetBillingAgreement - Use this call to get billing agreement details.
+// Endpoint: GET /v1/payments/billing-agreements/billing-agreements/ID
+func (c *Client) GetBillingAgreement(agreementID string) (*BillingAgreement, error) {
+	agreement := &BillingAgreement{}
+
+	req, err := c.NewRequest("GET", fmt.Sprintf("%s%s", c.APIBase, "/v1/payments/billing-agreements/"+agreementID), nil)
+	if err != nil {
+		return agreement, err
+	}
+
+	if err = c.SendWithAuth(req, agreement); err != nil {
+		return agreement, err
+	}
+
+	return agreement, nil
+}

--- a/types.go
+++ b/types.go
@@ -71,7 +71,7 @@ type (
 	// AgreementDetails struct
 	AgreementDetails struct {
 		OutstandingBalance AmountPayout `json:"outstanding_balance"`
-		CyclesRemaining    float64      `json:"cycles_remaining,string"`
+		CyclesRemaining    uint64       `json:"cycles_remaining,string"`
 		CyclesCompleted    int          `json:"cycles_completed,string"`
 		NextBillingDate    time.Time    `json:"next_billing_date"`
 		LastPaymentDate    time.Time    `json:"last_payment_date"`

--- a/types.go
+++ b/types.go
@@ -71,7 +71,7 @@ type (
 	// AgreementDetails struct
 	AgreementDetails struct {
 		OutstandingBalance AmountPayout `json:"outstanding_balance"`
-		CyclesRemaining    int          `json:"cycles_remaining,string"`
+		CyclesRemaining    float64      `json:"cycles_remaining,string"`
 		CyclesCompleted    int          `json:"cycles_completed,string"`
 		NextBillingDate    time.Time    `json:"next_billing_date"`
 		LastPaymentDate    time.Time    `json:"last_payment_date"`

--- a/types.go
+++ b/types.go
@@ -121,9 +121,11 @@ type (
 
 	// BillingAgreement struct
 	BillingAgreement struct {
-		Name            string           `json:"name,omitempty"`
-		Description     string           `json:"description,omitempty"`
-		StartDate       JSONTime         `json:"start_date,omitempty"`
+		Name        string `json:"name,omitempty"`
+		Description string `json:"description,omitempty"`
+		// StartDate must be of type JSONTime when creating new billing agreements
+		// When retrieving billing agreement details, StartDate will be of type time.Time
+		StartDate       interface{}      `json:"start_date,omitempty"`
 		Plan            BillingPlan      `json:"plan,omitempty"`
 		Payer           Payer            `json:"payer,omitempty"`
 		ShippingAddress *ShippingAddress `json:"shipping_address,omitempty"`

--- a/types.go
+++ b/types.go
@@ -125,10 +125,11 @@ type (
 		Description string `json:"description,omitempty"`
 		// StartDate must be of type JSONTime when creating new billing agreements
 		// When retrieving billing agreement details, StartDate will be of type time.Time
-		StartDate       interface{}      `json:"start_date,omitempty"`
-		Plan            BillingPlan      `json:"plan,omitempty"`
-		Payer           Payer            `json:"payer,omitempty"`
-		ShippingAddress *ShippingAddress `json:"shipping_address,omitempty"`
+		StartDate        interface{}       `json:"start_date,omitempty"`
+		Plan             BillingPlan       `json:"plan,omitempty"`
+		Payer            Payer             `json:"payer,omitempty"`
+		ShippingAddress  *ShippingAddress  `json:"shipping_address,omitempty"`
+		AgreementDetails *AgreementDetails `json:"agreement_details,omitempty"`
 	}
 
 	// BillingPlan struct


### PR DESCRIPTION
Quick and dirty but it works..

Get the billing agreement, including agreement details if available.

Two items of note:
- changed type for `BillingAgreement` StartDate to interface because field formatting is not the same for create vs get
- cycles remaining value is too big for int when agreement never expires, changed type to accommodate large numbers so json marshaler doesn't throw error