### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/payment.go
+++ b/payment.go
@@ -134,7 +134,7 @@ func (c *Client) GetPayments() ([]Payment, error) {
 	return c.getPayments(nil)
 }
 
-// GetPayments retrieve payments resources from Paypal by the provided filter
+// GetPaymentsWithFilter retrieve payments resources from Paypal by the provided filter
 // Endpoint: GET /v1/payments/payment/
 func (c *Client) GetPaymentsWithFilter(filter *Filter) ([]Payment, error) {
 	return c.getPayments(filter)


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?