### PR TITLE
Adding support for PayPal Order to contain Items

### DIFF
--- a/types.go
+++ b/types.go
@@ -316,6 +316,7 @@ type (
 		SKU         string `json:"sku,omitempty"`
 		Description string `json:"description,omitempty"`
 		Tax         string `json:"tax,omitempty"`
+		UnitAmount  *Money `json:"unit_amount,omitempty"`
 	}
 
 	// ItemList struct
@@ -334,6 +335,25 @@ type (
 
 	// PurchaseUnitAmount struct
 	PurchaseUnitAmount struct {
+		Currency  string                       `json:"currency_code"`
+		Value     string                       `json:"value"`
+		Breakdown *PurchaseUnitAmountBreakdown `json:"breakdown,omitempty"`
+	}
+
+	PurchaseUnitAmountBreakdown struct {
+		ItemTotal        *Money `json:"item_total,omitempty"`
+		Shipping         *Money `json:"shipping,omitempty"`
+		Handling         *Money `json:"handling,omitempty"`
+		TaxTotal         *Money `json:"tax_total,omitempty"`
+		Insurance        *Money `json:"insurance,omitempty"`
+		ShippingDiscount *Money `json:"shipping_discount,omitempty"`
+		Discount         *Money `json:"discount,omitempty"`
+	}
+
+	// Money struct
+	//
+	// https://developer.paypal.com/docs/api/orders/v2/#definition-money
+	Money struct {
 		Currency string `json:"currency_code"`
 		Value    string `json:"value"`
 	}


### PR DESCRIPTION
Using the latest version of the SDK, PayPal returns an error on Order creation, if the `PurchaseUnitRequest` contains items because the `unit_amount` field is missing in the JSON.

I added the `unit_amount` field and also needed to add the `Money` and `PurchaseUnitAmountBreakdown`. The breakdown is required, if the `unit_amount` field is set. See the [PayPal documentation of the `unit_amount` parameter](https://developer.paypal.com/docs/api/orders/v2/#definition-item) within an item.

## Example
```
purchaseUnits := []paypalsdk.PurchaseUnitRequest{
    {
        Amount: &paypalsdk.PurchaseUnitAmount{
            Currency: "EUR",
            Value:    "100.00",
        },
        Description: "Foo 42",
        Items: []paypalsdk.Item{
            {
                Name:     "Aufnahme 1",
                Currency: "EUR",
                Price:    "0.30",
                Quantity: 3,
            },
        },
    },
}
payerInfo := paypalsdk.PayerInfo{}
appContext := paypalsdk.ApplicationContext{
    BrandName: "Bar",
}

payPalClient := // client instantiation
order, err := payPalClient.CreateOrder(paypalsdk.OrderIntentCapture, purchaseUnits, &payerInfo, &appContext)
if err != nil {
     // will have an error
}
```
The error message tells us that the required field `unit_amount` is missing:
```
{"name":"INVALID_REQUEST","message":"Request is not well-formed, syntactically incorrect, or violates schema.","debug_id":"4730a542abbbb","details":[{"field":"/purchase_units/0/items/0/unit_amount","value":"","location":"body","issue":"MISSING_REQUIRED_PARAMETER","description":"A required field / parameter is missing."}],"links":[{"href":"https://developer.paypal.com/docs/api/orders/v2/#error-MISSING_REQUIRED_PARAMETER","rel":"information_link","encType":"application/json"}]}
```