### PR TITLE
Adding item category and shipping preference.

### DIFF
--- a/types.go
+++ b/types.go
@@ -62,6 +62,23 @@ const (
 	OrderIntentAuthorize string = "AUTHORIZE"
 )
 
+// Possible values for `category` in Item
+//
+// https://developer.paypal.com/docs/api/orders/v2/#definition-item
+const (
+	ItemCategoryDigitalGood  string = "DIGITAL_GOODS"
+	ItemCategoryPhysicalGood string = "PHYSICAL_GOODS"
+)
+
+// Possible values for `shipping_preference` in ApplicationContext
+//
+// https://developer.paypal.com/docs/api/orders/v2/#definition-application_context
+const (
+	ShippingPreferenceGetFromFile        string = "GET_FROM_FILE"
+	ShippingPreferenceNoShipping         string = "NO_SHIPPING"
+	ShippingPreferenceSetProvidedAddress string = "SET_PROVIDED_ADDRESS"
+)
+
 type (
 	// JSONTime overrides MarshalJson method to format in ISO8601
 	JSONTime time.Time
@@ -317,6 +334,7 @@ type (
 		Description string `json:"description,omitempty"`
 		Tax         string `json:"tax,omitempty"`
 		UnitAmount  *Money `json:"unit_amount,omitempty"`
+		Category    string `json:"category,omitempty"`
 	}
 
 	// ItemList struct


### PR DESCRIPTION
Previously we weren't able to (1) specify the product category and (2) had to specify the shipping preference enum values as user defined strings. With this PR we would:
1. be able to specify the products category
2. use framework provided enum values

Using these adjustments we are able to create PayPal Orders that don't list the shipping actions within the PayPal Order details.