### PR TITLE
Use v3 in tests to prevent indirect dependencies

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,6 +1,6 @@
 package paypal_test
 
-import paypal "github.com/plutov/paypal"
+import paypal "github.com/plutov/paypal/v3"
 
 func Example() {
 	// Initialize client


### PR DESCRIPTION
If we dont do this, v3 ends up depending on v2