### PR TITLE
Add custom_id to captured orders

### DIFF
--- a/types.go
+++ b/types.go
@@ -467,8 +467,9 @@ type (
 
 	// CaptureAmount struct
 	CaptureAmount struct {
-		ID     string              `json:"id,omitempty"`
-		Amount *PurchaseUnitAmount `json:"amount,omitempty"`
+		ID       string              `json:"id,omitempty"`
+		CustomID string              `json:"custom_id,omitempty"`
+		Amount   *PurchaseUnitAmount `json:"amount,omitempty"`
 	}
 
 	// CapturedPayments has the amounts for a captured order


### PR DESCRIPTION
Basically just adding `custom_id` to the capture order response, you can set the value when creating an order to relate server data to PayPal data (like storing customer ID or something).

Currently the capture order response does not track this field.