### PR TITLE
Add functions of create, get, update, delete and list webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ Currently supports **v2** only, if you want to use **v1**, use **v1.1.4** git ta
  * PATCH /v2/payments/billing-plans/***ID***
  * POST /v2/payments/billing-agreements
  * POST /v2/payments/billing-agreements/***TOKEN***/agreement-execute
+ * POST /v1/notifications/webhooks
+ * GET /v1/notifications/webhooks
+ * GET /v1/notifications/webhooks/**ID**
+ * PATCH /v1/notifications/webhooks/**ID**
+ * DELETE /v1/notifications/webhooks/**ID**
  * POST /v1/notifications/verify-webhook-signature
 
 ### Missing endpoints
@@ -279,6 +284,42 @@ c.GetCreditCard("CARD-ID-123")
 
 // Get all stored credit cards
 c.GetCreditCards(nil)
+```
+
+### Webhooks
+```go
+// Create a webhook
+c.CreateWebhook(paypal.CreateWebhookRequest{
+    URL: "webhook URL",
+    EventTypes: []WebhookEventType{
+        WebhookEventType{
+            Name: "PAYMENT.AUTHORIZATION.CREATED",
+            },
+    },
+})
+
+// Update a registered webhook
+c.UpdateWebhook("WebhookID", []WebhookField{
+    WebhookField{
+        Operation: "replace",
+        Path:      "/event_types",
+        Value: []interface{}{
+            map[string]interface{}{
+                "name": "PAYMENT.SALE.REFUNDED",
+            },
+        },
+    },
+})
+
+// Get a registered webhook
+c.GetWebhook("WebhookID")
+
+// Delete a webhook
+c.DeleteWebhook("WebhookID")
+
+// List registered webhooks
+c.ListWebhooks(paypal.AncorTypeApplication)
+
 ```
 
 ### How to Contribute

--- a/README.md
+++ b/README.md
@@ -291,16 +291,16 @@ c.GetCreditCards(nil)
 // Create a webhook
 c.CreateWebhook(paypal.CreateWebhookRequest{
     URL: "webhook URL",
-    EventTypes: []WebhookEventType{
-        WebhookEventType{
+    EventTypes: []paypal.WebhookEventType{
+        paypal.WebhookEventType{
             Name: "PAYMENT.AUTHORIZATION.CREATED",
             },
     },
 })
 
 // Update a registered webhook
-c.UpdateWebhook("WebhookID", []WebhookField{
-    WebhookField{
+c.UpdateWebhook("WebhookID", []paypal.WebhookField{
+    paypal.WebhookField{
         Operation: "replace",
         Path:      "/event_types",
         Value: []interface{}{

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,3 @@
 module github.com/plutov/paypal/v3
 
 go 1.12
-
-require (
-	github.com/brianvoe/gofakeit v3.18.0+incompatible
-	github.com/brianvoe/gofakeit/v5 v5.4.3
-)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/plutov/paypal/v3
 
 go 1.12
+
+require (
+	github.com/brianvoe/gofakeit v3.18.0+incompatible
+	github.com/brianvoe/gofakeit/v5 v5.4.3
+)

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,0 @@
-github.com/brianvoe/gofakeit v1.2.0 h1:GGbzCqQx9ync4ObAUhRa3F/M73eL9VZL3X09WoTwphM=
-github.com/brianvoe/gofakeit v3.18.0+incompatible h1:wDOmHc9DLG4nRjUVVaxA+CEglKOW72Y5+4WNxUIkjM8=
-github.com/brianvoe/gofakeit v3.18.0+incompatible/go.mod h1:kfwdRA90vvNhPutZWfH7WPaDzUjz+CZFqG+rPkOjGOc=
-github.com/brianvoe/gofakeit/v5 v5.4.3 h1:JWRVZTw81gV1RxNlNmBvZ+1oOqv0U6tMCne3mPXR9N8=
-github.com/brianvoe/gofakeit/v5 v5.4.3/go.mod h1:/ZENnKqX+XrN8SORLe/fu5lZDIo1tuPncWuRD+eyhSI=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,5 @@
+github.com/brianvoe/gofakeit v1.2.0 h1:GGbzCqQx9ync4ObAUhRa3F/M73eL9VZL3X09WoTwphM=
+github.com/brianvoe/gofakeit v3.18.0+incompatible h1:wDOmHc9DLG4nRjUVVaxA+CEglKOW72Y5+4WNxUIkjM8=
+github.com/brianvoe/gofakeit v3.18.0+incompatible/go.mod h1:kfwdRA90vvNhPutZWfH7WPaDzUjz+CZFqG+rPkOjGOc=
+github.com/brianvoe/gofakeit/v5 v5.4.3 h1:JWRVZTw81gV1RxNlNmBvZ+1oOqv0U6tMCne3mPXR9N8=
+github.com/brianvoe/gofakeit/v5 v5.4.3/go.mod h1:/ZENnKqX+XrN8SORLe/fu5lZDIo1tuPncWuRD+eyhSI=

--- a/integration_test.go
+++ b/integration_test.go
@@ -154,3 +154,14 @@ func TestCreateWebhook(t *testing.T) {
 		t.Errorf("Webhook couldn't be created, error %v", err)
 	}
 }
+
+func TestListWebhooks(t *testing.T) {
+	c, _ := NewClient(testClientID, testSecret, APIBaseSandBox)
+	c.GetAccessToken()
+
+	resp, err := c.ListWebhooks(AncorTypeApplication)
+	if err != nil {
+		fmt.Println(err)
+		t.Errorf("Cannot registered list webhooks, error %v", err)
+	}
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -136,8 +136,8 @@ func TestPatchCreditCard(t *testing.T) {
 	}
 }
 
-// Creates, gets, and deletes single webhook.
-func TestWebhook(t *testing.T) {
+// Creates, gets, and deletes single webhook
+func TestCreateAndGetWebhook(t *testing.T) {
 	c, _ := NewClient(testClientID, testSecret, APIBaseSandBox)
 	c.GetAccessToken()
 
@@ -158,6 +158,48 @@ func TestWebhook(t *testing.T) {
 	_, err = c.GetWebhook(createdWebhook.ID)
 	if err != nil {
 		t.Errorf("An error occurred while getting webhook, error %v", err)
+	}
+
+	err = c.DeleteWebhook(createdWebhook.ID)
+	if err != nil {
+		t.Errorf("An error occurred while webhooks deletion, error %v", err)
+	}
+}
+
+// Creates, updates, and deletes single webhook
+func TestCreateAndUpdateWebhook(t *testing.T) {
+	c, _ := NewClient(testClientID, testSecret, APIBaseSandBox)
+	c.GetAccessToken()
+
+	creationPayload := &CreateWebhookRequest{
+		URL: fmt.Sprintf("https://%s.com/paypal_webhooks", gofakeit.UUID()),
+		EventTypes: []WebhookEventType{
+			WebhookEventType{
+				Name: "PAYMENT.AUTHORIZATION.CREATED",
+			},
+		},
+	}
+
+	createdWebhook, err := c.CreateWebhook(creationPayload)
+	if err != nil {
+		t.Errorf("Webhook couldn't be created, error %v", err)
+	}
+
+	updatePayload := []WebhookField{
+		WebhookField{
+			Operation: "replace",
+			Path:      "/event_types",
+			Value: []interface{}{
+				map[string]interface{}{
+					"name": "PAYMENT.SALE.REFUNDED",
+				},
+			},
+		},
+	}
+
+	_, err = c.UpdateWebhook(createdWebhook.ID, updatePayload)
+	if err != nil {
+		t.Errorf("Couldn't update webhook, error %v", err)
 	}
 
 	err = c.DeleteWebhook(createdWebhook.ID)

--- a/integration_test.go
+++ b/integration_test.go
@@ -3,7 +3,10 @@
 package paypal
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/brianvoe/gofakeit"
 )
 
 // All test values are defined here
@@ -130,5 +133,24 @@ func TestPatchCreditCard(t *testing.T) {
 	r1, e1 := c.PatchCreditCard(testCardID, nil)
 	if e1 == nil || r1 != nil {
 		t.Errorf("Error is expected for empty update info")
+	}
+}
+
+func TestCreateWebhook(t *testing.T) {
+	c, _ := NewClient(testClientID, testSecret, APIBaseSandBox)
+	c.GetAccessToken()
+
+	payload := &CreateWebhookRequest{
+		URL: fmt.Sprintf("https://%s.com/paypal_webhooks", gofakeit.UUID()),
+		EventTypes: []WebhookEventType{
+			WebhookEventType{
+				Name: "PAYMENT.AUTHORIZATION.CREATED",
+			},
+		},
+	}
+
+	_, err := c.CreateWebhook(payload)
+	if err != nil {
+		t.Errorf("Webhook couldn't be created, error %v", err)
 	}
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -136,7 +136,8 @@ func TestPatchCreditCard(t *testing.T) {
 	}
 }
 
-func TestCreateAndDeleteWebhook(t *testing.T) {
+// Creates, gets, and deletes single webhook.
+func TestWebhook(t *testing.T) {
 	c, _ := NewClient(testClientID, testSecret, APIBaseSandBox)
 	c.GetAccessToken()
 
@@ -152,6 +153,11 @@ func TestCreateAndDeleteWebhook(t *testing.T) {
 	createdWebhook, err := c.CreateWebhook(payload)
 	if err != nil {
 		t.Errorf("Webhook couldn't be created, error %v", err)
+	}
+
+	_, err = c.GetWebhook(createdWebhook.ID)
+	if err != nil {
+		t.Errorf("An error occurred while getting webhook, error %v", err)
 	}
 
 	err = c.DeleteWebhook(createdWebhook.ID)

--- a/integration_test.go
+++ b/integration_test.go
@@ -3,10 +3,7 @@
 package paypal
 
 import (
-	"fmt"
 	"testing"
-
-	"github.com/brianvoe/gofakeit"
 )
 
 // All test values are defined here
@@ -142,7 +139,7 @@ func TestCreateAndGetWebhook(t *testing.T) {
 	c.GetAccessToken()
 
 	payload := &CreateWebhookRequest{
-		URL: fmt.Sprintf("https://%s.com/paypal_webhooks", gofakeit.UUID()),
+		URL: "https://example.com/paypal_webhooks",
 		EventTypes: []WebhookEventType{
 			WebhookEventType{
 				Name: "PAYMENT.AUTHORIZATION.CREATED",
@@ -172,7 +169,7 @@ func TestCreateAndUpdateWebhook(t *testing.T) {
 	c.GetAccessToken()
 
 	creationPayload := &CreateWebhookRequest{
-		URL: fmt.Sprintf("https://%s.com/paypal_webhooks", gofakeit.UUID()),
+		URL: "https://example.com/paypal_webhooks",
 		EventTypes: []WebhookEventType{
 			WebhookEventType{
 				Name: "PAYMENT.AUTHORIZATION.CREATED",

--- a/integration_test.go
+++ b/integration_test.go
@@ -136,7 +136,7 @@ func TestPatchCreditCard(t *testing.T) {
 	}
 }
 
-func TestCreateWebhook(t *testing.T) {
+func TestCreateAndDeleteWebhook(t *testing.T) {
 	c, _ := NewClient(testClientID, testSecret, APIBaseSandBox)
 	c.GetAccessToken()
 
@@ -149,9 +149,14 @@ func TestCreateWebhook(t *testing.T) {
 		},
 	}
 
-	_, err := c.CreateWebhook(payload)
+	createdWebhook, err := c.CreateWebhook(payload)
 	if err != nil {
 		t.Errorf("Webhook couldn't be created, error %v", err)
+	}
+
+	err = c.DeleteWebhook(createdWebhook.ID)
+	if err != nil {
+		t.Errorf("An error occurred while webhooks deletion, error %v", err)
 	}
 }
 
@@ -159,9 +164,8 @@ func TestListWebhooks(t *testing.T) {
 	c, _ := NewClient(testClientID, testSecret, APIBaseSandBox)
 	c.GetAccessToken()
 
-	resp, err := c.ListWebhooks(AncorTypeApplication)
+	_, err := c.ListWebhooks(AncorTypeApplication)
 	if err != nil {
-		fmt.Println(err)
 		t.Errorf("Cannot registered list webhooks, error %v", err)
 	}
 }

--- a/types.go
+++ b/types.go
@@ -1010,6 +1010,12 @@ type (
 		Webhooks []Webhook `json:"webhooks"`
 	}
 
+	WebhookField struct {
+		Operation string      `json:"op"`
+		Path      string      `json:"path"`
+		Value     interface{} `json:"value"`
+	}
+
 	Resource struct {
 		// Payment Resource type
 		ID                     string                  `json:"id,omitempty"`

--- a/types.go
+++ b/types.go
@@ -963,10 +963,12 @@ type (
 		UserAction        string `json:"user_action,omitempty"`
 	}
 
+	// VerifyWebhookResponse struct
 	VerifyWebhookResponse struct {
 		VerificationStatus string `json:"verification_status,omitempty"`
 	}
 
+	// WebhookEvent struct
 	WebhookEvent struct {
 		ID              string    `json:"id"`
 		CreateTime      time.Time `json:"create_time"`
@@ -977,6 +979,26 @@ type (
 		Links           []Link    `json:"links"`
 		EventVersion    string    `json:"event_version,omitempty"`
 		ResourceVersion string    `json:"resource_version,omitempty"`
+	}
+
+	// WebhookEventType struct
+	WebhookEventType struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	}
+
+	// CreateWebhookRequest struct
+	CreateWebhookRequest struct {
+		URL        string             `json:"url"`
+		EventTypes []WebhookEventType `json:"event_types"`
+	}
+
+	// CreateWebhookResponse struct
+	CreateWebhookResponse struct {
+		ID         string             `json:"id"`
+		URL        string             `json:"url"`
+		EventTypes []WebhookEventType `json:"event_types"`
+		Links      []Link             `json:"links"`
 	}
 
 	Resource struct {

--- a/types.go
+++ b/types.go
@@ -124,6 +124,11 @@ const (
 	LinkRelActionURL string = "action_url"
 )
 
+const (
+	AncorTypeApplication string = "APPLICATION"
+	AncorTypeAccount     string = "ACCOUNT"
+)
+
 type (
 	// JSONTime overrides MarshalJson method to format in ISO8601
 	JSONTime time.Time
@@ -968,6 +973,14 @@ type (
 		VerificationStatus string `json:"verification_status,omitempty"`
 	}
 
+	// Webhook strunct
+	Webhook struct {
+		ID         string             `json:"id"`
+		URL        string             `json:"url"`
+		EventTypes []WebhookEventType `json:"event_types"`
+		Links      []Link             `json:"links"`
+	}
+
 	// WebhookEvent struct
 	WebhookEvent struct {
 		ID              string    `json:"id"`
@@ -999,6 +1012,10 @@ type (
 		URL        string             `json:"url"`
 		EventTypes []WebhookEventType `json:"event_types"`
 		Links      []Link             `json:"links"`
+	}
+
+	ListWebhookResponse struct {
+		Webhooks []Webhook `json:"webhooks"`
 	}
 
 	Resource struct {

--- a/types.go
+++ b/types.go
@@ -1006,14 +1006,6 @@ type (
 		EventTypes []WebhookEventType `json:"event_types"`
 	}
 
-	// CreateWebhookResponse struct
-	CreateWebhookResponse struct {
-		ID         string             `json:"id"`
-		URL        string             `json:"url"`
-		EventTypes []WebhookEventType `json:"event_types"`
-		Links      []Link             `json:"links"`
-	}
-
 	ListWebhookResponse struct {
 		Webhooks []Webhook `json:"webhooks"`
 	}

--- a/webhooks.go
+++ b/webhooks.go
@@ -40,6 +40,21 @@ func (c *Client) ListWebhooks(anchorType string) (*ListWebhookResponse, error) {
 	return resp, err
 }
 
+// DeleteWebhook - Deletes a webhook, by ID.
+// Endpoint: DELETE /v1/notifications/webhooks/ID
+func (c *Client) DeleteWebhook(webhookID string) error {
+	req, err := c.NewRequest(http.MethodDelete, fmt.Sprintf("%s/v1/notifications/webhooks/%s", c.APIBase, webhookID), nil)
+	if err != nil {
+		return err
+	}
+
+	if err = c.SendWithAuth(req, nil); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // VerifyWebhookSignature - Use this to verify the signature of a webhook recieved from paypal.
 // Endpoint: POST /v1/notifications/verify-webhook-signature
 func (c *Client) VerifyWebhookSignature(httpReq *http.Request, webhookID string) (*VerifyWebhookResponse, error) {

--- a/webhooks.go
+++ b/webhooks.go
@@ -30,11 +30,8 @@ func (c *Client) GetWebhook(webhookID string) (*Webhook, error) {
 		return webhook, err
 	}
 
-	if err = c.SendWithAuth(req, webhook); err != nil {
-		return webhook, err
-	}
-
-	return webhook, nil
+	err = c.SendWithAuth(req, webhook)
+	return webhook, err
 }
 
 // UpdateWebhook - Updates a webhook to replace webhook fields with new values.
@@ -46,11 +43,8 @@ func (c *Client) UpdateWebhook(webhookID string, fields []WebhookField) (*Webhoo
 		return webhook, err
 	}
 
-	if err = c.SendWithAuth(req, webhook); err != nil {
-		return webhook, err
-	}
-
-	return webhook, nil
+	err = c.SendWithAuth(req, webhook)
+	return webhook, err
 }
 
 // ListWebhooks - Lists webhooks for an app.
@@ -65,7 +59,7 @@ func (c *Client) ListWebhooks(anchorType string) (*ListWebhookResponse, error) {
 	req.URL.RawQuery = q.Encode()
 	resp := &ListWebhookResponse{}
 	if err != nil {
-		return resp, err
+		return nil, err
 	}
 
 	err = c.SendWithAuth(req, resp)
@@ -80,11 +74,8 @@ func (c *Client) DeleteWebhook(webhookID string) error {
 		return err
 	}
 
-	if err = c.SendWithAuth(req, nil); err != nil {
-		return err
-	}
-
-	return nil
+	err = c.SendWithAuth(req, nil)
+	return err
 }
 
 // VerifyWebhookSignature - Use this to verify the signature of a webhook recieved from paypal.

--- a/webhooks.go
+++ b/webhooks.go
@@ -8,6 +8,19 @@ import (
 	"net/http"
 )
 
+// CreateWebhook - Subscribes your webhook listener to events.
+// Endpoint: POST /v1/notifications/webhooks
+func (c *Client) CreateWebhook(createWebhookRequest *CreateWebhookRequest) (*CreateWebhookResponse, error) {
+	req, err := c.NewRequest(http.MethodPost, fmt.Sprintf("%s%s", c.APIBase, "/v1/notifications/webhooks"), createWebhookRequest)
+	res := &CreateWebhookResponse{}
+	if err != nil {
+		return res, err
+	}
+
+	err = c.SendWithAuth(req, res)
+	return res, err
+}
+
 // VerifyWebhookSignature - Use this to verify the signature of a webhook recieved from paypal.
 // Endpoint: POST /v1/notifications/verify-webhook-signature
 func (c *Client) VerifyWebhookSignature(httpReq *http.Request, webhookID string) (*VerifyWebhookResponse, error) {

--- a/webhooks.go
+++ b/webhooks.go
@@ -37,6 +37,22 @@ func (c *Client) GetWebhook(webhookID string) (*Webhook, error) {
 	return webhook, nil
 }
 
+// UpdateWebhook - Updates a webhook to replace webhook fields with new values.
+// Endpoint: PATCH /v1/notifications/webhooks/ID
+func (c *Client) UpdateWebhook(webhookID string, fields []WebhookField) (*Webhook, error) {
+	req, err := c.NewRequest(http.MethodPatch, fmt.Sprintf("%s/v1/notifications/webhooks/%s", c.APIBase, webhookID), fields)
+	webhook := &Webhook{}
+	if err != nil {
+		return webhook, err
+	}
+
+	if err = c.SendWithAuth(req, webhook); err != nil {
+		return webhook, err
+	}
+
+	return webhook, nil
+}
+
 // ListWebhooks - Lists webhooks for an app.
 // Endpoint: GET /v1/notifications/webhooks
 func (c *Client) ListWebhooks(anchorType string) (*ListWebhookResponse, error) {

--- a/webhooks.go
+++ b/webhooks.go
@@ -21,6 +21,25 @@ func (c *Client) CreateWebhook(createWebhookRequest *CreateWebhookRequest) (*Cre
 	return res, err
 }
 
+// ListWebhooks - Lists webhooks for an app.
+// Endpoint: GET /v1/notifications/webhooks
+func (c *Client) ListWebhooks(anchorType string) (*ListWebhookResponse, error) {
+	if len(anchorType) == 0 {
+		anchorType = AncorTypeApplication
+	}
+	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.APIBase, "/v1/notifications/webhooks"), nil)
+	q := req.URL.Query()
+	q.Add("anchor_type", anchorType)
+	req.URL.RawQuery = q.Encode()
+	resp := &ListWebhookResponse{}
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.SendWithAuth(req, resp)
+	return resp, err
+}
+
 // VerifyWebhookSignature - Use this to verify the signature of a webhook recieved from paypal.
 // Endpoint: POST /v1/notifications/verify-webhook-signature
 func (c *Client) VerifyWebhookSignature(httpReq *http.Request, webhookID string) (*VerifyWebhookResponse, error) {

--- a/webhooks.go
+++ b/webhooks.go
@@ -10,15 +10,31 @@ import (
 
 // CreateWebhook - Subscribes your webhook listener to events.
 // Endpoint: POST /v1/notifications/webhooks
-func (c *Client) CreateWebhook(createWebhookRequest *CreateWebhookRequest) (*CreateWebhookResponse, error) {
+func (c *Client) CreateWebhook(createWebhookRequest *CreateWebhookRequest) (*Webhook, error) {
 	req, err := c.NewRequest(http.MethodPost, fmt.Sprintf("%s%s", c.APIBase, "/v1/notifications/webhooks"), createWebhookRequest)
-	res := &CreateWebhookResponse{}
+	webhook := &Webhook{}
 	if err != nil {
-		return res, err
+		return webhook, err
 	}
 
-	err = c.SendWithAuth(req, res)
-	return res, err
+	err = c.SendWithAuth(req, webhook)
+	return webhook, err
+}
+
+// GetWebhook - Shows details for a webhook, by ID.
+// Endpoint: GET /v1/notifications/webhooks/ID
+func (c *Client) GetWebhook(webhookID string) (*Webhook, error) {
+	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s%s", c.APIBase, "/v1/notifications/webhooks/", webhookID), nil)
+	webhook := &Webhook{}
+	if err != nil {
+		return webhook, err
+	}
+
+	if err = c.SendWithAuth(req, webhook); err != nil {
+		return webhook, err
+	}
+
+	return webhook, nil
 }
 
 // ListWebhooks - Lists webhooks for an app.


### PR DESCRIPTION
Hi,

I added new functionalities related to create, get, update, delete and list webhooks as they are defined in [Paypal API](https://developer.paypal.com/docs/api/webhooks/v1/#webhooks)

Endpoints:
* POST /v1/notifications/webhooks
* GET /v1/notifications/webhooks
* GET /v1/notifications/webhooks/**ID**
* PATCH /v1/notifications/webhooks/**ID**
* DELETE /v1/notifications/webhooks/**ID**
