### PR TITLE
Added missing Sale struct

### DIFF
--- a/types.go
+++ b/types.go
@@ -798,11 +798,13 @@ type (
 	// Sale struct
 	Sale struct {
 		ID                        string     `json:"id,omitempty"`
+		State                     string     `json:"state,omitempty"`
 		Amount                    *Amount    `json:"amount,omitempty"`
 		TransactionFee            *Currency  `json:"transaction_fee,omitempty"`
+		InvoiceNumber string `json:"invoice_number,omitempty"`
+		BillingAgreementId string `json:"billing_agreement_id,omitempty"`
 		Description               string     `json:"description,omitempty"`
 		CreateTime                *time.Time `json:"create_time,omitempty"`
-		State                     string     `json:"state,omitempty"`
 		ParentPayment             string     `json:"parent_payment,omitempty"`
 		UpdateTime                *time.Time `json:"update_time,omitempty"`
 		PaymentMode               string     `json:"payment_mode,omitempty"`


### PR DESCRIPTION
#### What does this PR do?
When receiving payments via subscriptions (notified via webhooks), a critical information is missing in the payment data, which is which subscription this payment belongs to. 

#### Where should the reviewer start?
types.go

#### How should this be manually tested?
When you receive payment notification via webhook, the payment must contain the ID of the subscription it belongs to. this data was missing.

#### Any background context you want to provide?
nope