### PR TITLE
change SharedListResponse TotalItems, TotalPages from string to int; …

### DIFF
--- a/types.go
+++ b/types.go
@@ -1204,8 +1204,8 @@ type (
 	}
 
 	SharedListResponse struct {
-		TotalItems string `json:"total_items,omitempty"`
-		TotalPages string `json:"total_pages,omitempty"`
+		TotalItems int    `json:"total_items,omitempty"`
+		TotalPages int    `json:"total_pages,omitempty"`
 		Links      []Link `json:"links,omitempty"`
 	}
 )


### PR DESCRIPTION
…Error: json: cannot unmarshal number into Go struct field ListSubscriptionPlansResponse.total_items of type string

The function ListSubscriptionPlans can't set the response fom paypal-api to struct, the mashaller tries unmashal number to string.

Error: "json: cannot unmarshal number into Go struct field ListSubscriptionPlansResponse.total_items of type string" 


