### PR TITLE
Adds SellerReceivableBreakdown and CustomID fields to the Resource type

### DIFF
--- a/types.go
+++ b/types.go
@@ -1048,17 +1048,19 @@ type (
 
 	Resource struct {
 		// Payment Resource type
-		ID                     string                  `json:"id,omitempty"`
-		Status                 string                  `json:"status,omitempty"`
-		StatusDetails          *CaptureStatusDetails   `json:"status_details,omitempty"`
-		Amount                 *PurchaseUnitAmount     `json:"amount,omitempty"`
-		UpdateTime             string                  `json:"update_time,omitempty"`
-		CreateTime             string                  `json:"create_time,omitempty"`
-		ExpirationTime         string                  `json:"expiration_time,omitempty"`
-		SellerProtection       *SellerProtection       `json:"seller_protection,omitempty"`
-		FinalCapture           bool                    `json:"final_capture,omitempty"`
-		SellerPayableBreakdown *CaptureSellerBreakdown `json:"seller_payable_breakdown,omitempty"`
-		NoteToPayer            string                  `json:"note_to_payer,omitempty"`
+		ID                        string                     `json:"id,omitempty"`
+		Status                    string                     `json:"status,omitempty"`
+		StatusDetails             *CaptureStatusDetails      `json:"status_details,omitempty"`
+		Amount                    *PurchaseUnitAmount        `json:"amount,omitempty"`
+		UpdateTime                string                     `json:"update_time,omitempty"`
+		CreateTime                string                     `json:"create_time,omitempty"`
+		ExpirationTime            string                     `json:"expiration_time,omitempty"`
+		SellerProtection          *SellerProtection          `json:"seller_protection,omitempty"`
+		FinalCapture              bool                       `json:"final_capture,omitempty"`
+		SellerPayableBreakdown    *CaptureSellerBreakdown    `json:"seller_payable_breakdown,omitempty"`
+		SellerReceivableBreakdown *SellerReceivableBreakdown `json:"seller_receivable_breakdown,omitempty"`
+		NoteToPayer               string                     `json:"note_to_payer,omitempty"`
+		CustomID                  string                     `json:"custom_id,omitempty"`
 		// merchant-onboarding Resource type
 		PartnerClientID string `json:"partner_client_id,omitempty"`
 		MerchantID      string `json:"merchant_id,omitempty"`

--- a/types.go
+++ b/types.go
@@ -87,6 +87,7 @@ const (
 // https://developer.paypal.com/docs/api/orders/v2/#definition-application_context
 
 const (
+	EventCheckoutOrderApproved         string = "CHECKOUT.ORDER.APPROVED"
 	EventPaymentCaptureCompleted       string = "PAYMENT.CAPTURE.COMPLETED"
 	EventPaymentCaptureDenied          string = "PAYMENT.CAPTURE.DENIED"
 	EventPaymentCaptureRefunded        string = "PAYMENT.CAPTURE.REFUNDED"
@@ -1064,6 +1065,10 @@ type (
 		// merchant-onboarding Resource type
 		PartnerClientID string `json:"partner_client_id,omitempty"`
 		MerchantID      string `json:"merchant_id,omitempty"`
+		// Checkout Resource type
+		Intent        string                 `json:"intent,omitempty"`
+		PurchaseUnits []*PurchaseUnitRequest `json:"purchase_units,omitempty"`
+		Payer         *PayerWithNameAndPhone `json:"payer,omitempty"`
 		// Common
 		Links []Link `json:"links,omitempty"`
 	}


### PR DESCRIPTION
This adds a couple of fields to the `Resource` type for information contained in `PAYMENT.CAPTURE.COMPLETED` webhooks.  Column alignment was changed due to the longer field name and to keep with code formatting.