### PR TITLE
Adds a CustomID field to the SubscriptionBase struct

### DIFF
--- a/subscription.go
+++ b/subscription.go
@@ -15,6 +15,7 @@ type (
 		Subscriber         *Subscriber         `json:"subscriber,omitempty"`
 		AutoRenewal        bool               `json:"auto_renewal,omitempty"`
 		ApplicationContext *ApplicationContext `json:"application_context,omitempty"`
+		CustomID           string              `json:"custom_id,omitempty"`
 	}
 
 	SubscriptionDetails struct {


### PR DESCRIPTION
#### What does this PR do?

Adds a CustomID field to the SubscriptionBase struct

#### Where should the reviewer start?

subscription.go

#### How should this be manually tested?

`go test`

#### Any background context you want to provide?

Required to assign the `custom_id` field to subscription events.