### PR TITLE
Fix omitempty tags on Product struct

### DIFF
--- a/products.go
+++ b/products.go
@@ -9,12 +9,12 @@ type (
 	// Product struct
 	Product struct {
 		ID          string          `json:"id,omitempty"`
-		Name        string          `json:"name,omitempty"`
-		Description string          `json:"description"`
+		Name        string          `json:"name"`
+		Description string          `json:"description",omitempty`
 		Category    ProductCategory `json:"category,omitempty"`
 		Type        ProductType     `json:"type"`
-		ImageUrl    string          `json:"image_url"`
-		HomeUrl     string          `json:"home_url"`
+		ImageUrl    string          `json:"image_url,omitempty"`
+		HomeUrl     string          `json:"home_url,omitempty"`
 	}
 
 	CreateProductResponse struct {


### PR DESCRIPTION
#### What does this PR do?

Changes the `omitempty` tags on the Product struct to match Paypal API requirements.  

#### Where should the reviewer start?

products.go

#### How should this be manually tested?

The following code results in an error:

```
  if product, err := client.CreateProduct(paypal.Product{
    Name: `Digital subscription`,
    Type: paypal.ProductTypeDigital,
  }); err != nil {
    return nil, err
  } else {
    return product, nil
  }
```

Error returned from Paypal:

```
400 Request is not well-formed, syntactically incorrect, or violates schema., [{Field:/home_url Issue:INVALID_PARAMETER_VALUE Links:[]} {Field:/image_url Issue:INVALID_PARAMETER_VALUE Links:[]} {Field:/image_url Issue:INVALID_PARAMETER_SYNTAX Links:[]} {Field:/description Issue:INVALID_PARAMETER_VALUE Links:[]} {Field:/home_url Issue:INVALID_PARAMETER_SYNTAX Links:[]}]
```

#### Any background context you want to provide?

The API specification states that only `name` and `type` are required.  As tagged the Product struct will omit `name` and send `description`, `home_url`, and `image_url` as empty which causes the validation errors described above.