### PR TITLE
Fix omitempty struct tag for Product.Description

### DIFF
--- a/products.go
+++ b/products.go
@@ -11,7 +11,7 @@ type (
 	Product struct {
 		ID          string          `json:"id,omitempty"`
 		Name        string          `json:"name"`
-		Description string          `json:"description",omitempty`
+		Description string          `json:"description,omitempty`
 		Category    ProductCategory `json:"category,omitempty"`
 		Type        ProductType     `json:"type"`
 		ImageUrl    string          `json:"image_url,omitempty"`


### PR DESCRIPTION
#### What does this PR do?
Fixes
```
struct field tag `json:"description",omitempty` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spacesstructtag
```
#### Where should the reviewer start?
#### How should this be manually tested?
#### Any background context you want to provide?