### PR TITLE
remove invalid event structs

### DIFF
--- a/types.go
+++ b/types.go
@@ -1051,7 +1051,7 @@ type (
 		EventTypes []WebhookEventType `json:"event_types"`
 	}
 
-	// Webhook strunct
+	// Webhook struct
 	Webhook struct {
 		ID         string             `json:"id"`
 		URL        string             `json:"url"`
@@ -1059,7 +1059,10 @@ type (
 		Links      []Link             `json:"links"`
 	}
 
-	// Event struct
+	// Event struct.
+	//
+	// The basic webhook event data type. This struct is intended to be
+	// embedded into resource type specific event structs.
 	Event struct {
 		ID              string    `json:"id"`
 		CreateTime      time.Time `json:"create_time"`
@@ -1074,16 +1077,6 @@ type (
 	AnyEvent struct {
 		Event
 		Resource json.RawMessage `json:"resource"`
-	}
-
-	PaymentPayoutsItemEvent struct {
-		Event
-		Resource PayoutItemResponse `json:"resource"`
-	}
-
-	PaymentPayoutsBatchEvent struct {
-		Event
-		Resource PayoutResponse `json:"resource"`
 	}
 
 	// WebhookEventType struct


### PR DESCRIPTION
Sorry if my last issue about this were not clear. These two were just simplified examples and don't contain everything so it's best they are removed for the time being. 

If the concrete events really are going to be included in this package it means that probably somewhere between 30-60 structs has to be added which is kind of noisy. 

As I wrote in https://github.com/plutov/paypal/issues/192 it's maybe even even a good idea if the concrete webhook event types become their separate module.

I'm guessing it's safe to delete these because anyone who as tried to use them should have found out that they are missing a lot of data.