### PR TITLE
Adding functions for requesting billing agreement token

### DIFF
--- a/billing_agreements.go
+++ b/billing_agreements.go
@@ -32,7 +32,7 @@ func (c *Client) CreateBillingAgreementToken(
 		fmt.Sprintf("%s%s", c.APIBase, "/v1/billing-agreements/agreement-tokens"),
 		createBARequest{Name: name, Description: description, StartDate: startDate, Payer: payer, Plan: plan})
 	if err != nil {
-		return billingAgreementToken, err
+		return nil, err
 	}
 
 	if err = c.SendWithAuth(req, billingAgreementToken); err != nil {

--- a/billing_agreements.go
+++ b/billing_agreements.go
@@ -14,14 +14,14 @@ func (c *Client) CreateBillingAgreementToken(
 	startDate string,
 	payer *Payer,
 	plan *BillingPlan,
-	) (*BillingAgreementToken, error) {
+) (*BillingAgreementToken, error) {
 
 	type createBARequest struct {
-		Name	string	`json:"name"`
-		Description	string	`json:"description"`
-		StartDate	string	`json:"start_date"`
-		Payer	*Payer	`json:"payer"`
-		Plan	*BillingPlan	`json:"plan"`
+		Name        string       `json:"name"`
+		Description string       `json:"description"`
+		StartDate   string       `json:"start_date"`
+		Payer       *Payer       `json:"payer"`
+		Plan        *BillingPlan `json:"plan"`
 	}
 
 	billingAgreementToken := &BillingAgreementToken{}

--- a/billing_agreements.go
+++ b/billing_agreements.go
@@ -15,7 +15,6 @@ func (c *Client) CreateBillingAgreementToken(
 	payer *Payer,
 	plan *BillingPlan,
 ) (*BillingAgreementToken, error) {
-
 	type createBARequest struct {
 		Name        string       `json:"name"`
 		Description string       `json:"description"`

--- a/billing_agreements.go
+++ b/billing_agreements.go
@@ -1,0 +1,43 @@
+package paypal
+
+import (
+	"context"
+	"fmt"
+)
+
+// CreateBillingAgreementToken - Use this call to create a billing agreement
+// Endpoint: POST /v1/billing-agreements/agreement-tokens
+func (c *Client) CreateBillingAgreementToken(
+	ctx context.Context,
+	name string,
+	description string,
+	startDate string,
+	payer *Payer,
+	plan *BillingPlan,
+	) (*BillingAgreementToken, error) {
+
+	type createBARequest struct {
+		Name	string	`json:"name"`
+		Description	string	`json:"description"`
+		StartDate	string	`json:"start_date"`
+		Payer	*Payer	`json:"payer"`
+		Plan	*BillingPlan	`json:"plan"`
+	}
+
+	billingAgreementToken := &BillingAgreementToken{}
+
+	req, err := c.NewRequest(
+		ctx,
+		"POST",
+		fmt.Sprintf("%s%s", c.APIBase, "/v1/billing-agreements/agreement-tokens"),
+		createBARequest{Name: name, Description: description, StartDate: startDate, Payer: payer, Plan: plan})
+	if err != nil {
+		return billingAgreementToken, err
+	}
+
+	if err = c.SendWithAuth(req, billingAgreementToken); err != nil {
+		return billingAgreementToken, err
+	}
+
+	return billingAgreementToken, nil
+}

--- a/types.go
+++ b/types.go
@@ -328,6 +328,36 @@ type (
 		OverrideMerchantPreferences *MerchantPreferences `json:"override_merchant_preferences,omitempty"`
 	}
 
+	// BillingAgreementToken response struct
+	BillingAgreementToken struct {
+		ID                          string               `json:"id,omitempty"`
+		Name                        string               `json:"name,omitempty"`
+		Description                 string               `json:"description,omitempty"`
+		StartDate                   string               `json:"start_date,omitempty"`
+		AgreementDetails            *AgreementDetails    `json:"agreement_details,omitempty"`
+		Payer                       *Payer               `json:"payer,omitempty"`
+		ShippingAddress             *ShippingAddress     `json:"shipping_address,omitempty"`
+		OverrideMerchantPreferences *MerchantPreferences `json:"override_merchant_preferences,omitempty"`
+		OverrideChargeModels        *OverrideChargeModel `json:"override_charge_models,omitempty"`
+		Plan                        *Plan                `json:"plan,omitempty"`
+	}
+
+	//OverrideChargeModel struct
+	OverrideChargeModel struct {
+		ChargeID string  `json:"charge_id"`
+		Amount   *Amount `json:"amount"`
+	}
+
+	// Plan struct
+	Plan struct {
+		ID                 string              `json:"id"`
+		Name               string              `json:"name"`
+		Description        string              `json:"description"`
+		CreateTime         string              `json:"create_time,omitempty"`
+		UpdateTime         string              `json:"update_time,omitempty"`
+		PaymentDefinitions []PaymentDefinition `json:"payment_definitions,omitempty"`
+	}
+
 	// BillingInfo struct
 	BillingInfo struct {
 		OutstandingBalance  AmountPayout      `json:"outstanding_balance,omitempty"`

--- a/unit_test.go
+++ b/unit_test.go
@@ -392,6 +392,11 @@ func (ts *webprofileTestServer) ServeHTTP(w http.ResponseWriter, r *http.Request
 			ts.deleteinvalid(w, r)
 		}
 	}
+	if r.RequestURI == "/v1/billing-agreements/agreement-tokens" {
+		if r.Method == "POST" {
+			ts.create(w, r)
+		}
+	}
 }
 
 func (ts *webprofileTestServer) create(w http.ResponseWriter, r *http.Request) {
@@ -740,6 +745,27 @@ func TestDeleteWebProfile_invalid(t *testing.T) {
 	err := c.DeleteWebProfile(context.Background(), "foobar")
 
 	if err == nil {
+		t.Fatal(err)
+	}
+
+}
+
+func TestCreateBillingAgreementToken(t *testing.T) {
+
+	ts := httptest.NewServer(&webprofileTestServer{t: t})
+	defer ts.Close()
+
+	c, _ := NewClient("foo", "bar", ts.URL)
+
+	_, err := c.CreateBillingAgreementToken(
+		context.Background(),
+		"name A",
+		"description A",
+		"start date A",
+		&Payer{PaymentMethod: "paypal"},
+		&BillingPlan{ID: "id B", Name: "name B", Description: "description B", Type: "type B"})
+
+	if err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
#### What does this PR do?

This PR adds the **CreateBillingAgreementToken** function to facilitate the API call which should return a billing agreement token. To do so, it adds types **BillingAgreementToken**, **OverrideChargeModel**, and **Plan** based on [this](https://developer.paypal.com/docs/api/payments.billing-agreements/v1/#definition-agreement_details) documentation.

#### Where should the reviewer start?

The new file, **billing_agreements.go**, includes the new logic, while **types.go** includes the new structs to support that logic.

#### How should this be manually tested?

Added test in **unit_test.go**.

#### Any background context you want to provide?