### PR TITLE
Added missing BillingAgreementId key in webhook

### DIFF
--- a/types.go
+++ b/types.go
@@ -1150,7 +1150,7 @@ type (
 		PartnerClientID           string                     `json:"partner_client_id,omitempty"`
 		MerchantID                string                     `json:"merchant_id,omitempty"`
 		Intent                    string                     `json:"intent,omitempty"`
-		BillingAgreementId        *string                    `json:"billing_agreement_id,omitempty"`
+		BillingAgreementID        *string                    `json:"billing_agreement_id,omitempty"`
 		PurchaseUnits             []*PurchaseUnitRequest     `json:"purchase_units,omitempty"`
 		Payer                     *PayerWithNameAndPhone     `json:"payer,omitempty"`
 		Links                     []Link                     `json:"links,omitempty"`

--- a/types.go
+++ b/types.go
@@ -1150,6 +1150,7 @@ type (
 		PartnerClientID           string                     `json:"partner_client_id,omitempty"`
 		MerchantID                string                     `json:"merchant_id,omitempty"`
 		Intent                    string                     `json:"intent,omitempty"`
+		BillingAgreementId        *string                    `json:"billing_agreement_id,omitempty"`
 		PurchaseUnits             []*PurchaseUnitRequest     `json:"purchase_units,omitempty"`
 		Payer                     *PayerWithNameAndPhone     `json:"payer,omitempty"`
 		Links                     []Link                     `json:"links,omitempty"`


### PR DESCRIPTION
Webhook resource contains `billing_agreement_id`. Exists in type: `PAYMENT.SALE.COMPLETED` when a subscription is paid.

#### What does this PR do?
- Added new key in existed type.
#### Where should the reviewer start?
- only one row
#### How should this be manually tested?
- create subscription
- pay subscription
- receive  `PAYMENT.SALE.COMPLETED` webhook
#### Any background context you want to provide?
- not, I'm not.