### PR TITLE
Convert depracation comments to godoc and deprecate Resource struct.

### DIFF
--- a/billing.go
+++ b/billing.go
@@ -20,7 +20,9 @@ type (
 		Links               []Link              `json:"links,omitempty"`
 	}
 
-	// CreateBillingResp deprecated, use CreateBillingResponse instead.
+	// CreateBillingResp.
+	//
+	// Deprecated: use CreateBillingResponse instead.
 	CreateBillingResp = CreateBillingResponse
 
 	// CreateAgreementResponse struct
@@ -32,22 +34,26 @@ type (
 		StartTime   time.Time   `json:"start_time,omitempty"`
 	}
 
-	// CreateAgreementResp is deprecated, use CreateAgreementResponse instead.
+	// CreateAgreementResp.
+	//
+	// Deprecated: use CreateAgreementResponse instead.
 	CreateAgreementResp =  CreateAgreementResponse
 
-	// BillingPlanListParams struct
+	// BillingPlanListParams
 	BillingPlanListParams struct {
 		ListParams
 		Status string `json:"status,omitempty"` //Allowed values: CREATED, ACTIVE, INACTIVE, ALL.
 	}
 
-	//BillingPlanListResponse struct
+	// BillingPlanListResponse
 	BillingPlanListResponse struct {
 		SharedListResponse
 		Plans []BillingPlan `json:"plans,omitempty"`
 	}
 
-	// BillingPlanListResp is deprecated, use BillingPlanListResponse instead.
+	// BillingPlanListResp.
+	//
+	// Deprecated: use BillingPlanListResponse instead.
 	BillingPlanListResp = BillingPlanListResponse
 )
 

--- a/types.go
+++ b/types.go
@@ -1132,8 +1132,16 @@ type (
 		Value     interface{} `json:"value"`
 	}
 
+	// Resource is a mix of fields from several webhook resource types.
+	//
+	// Deprecated: Add implementation of specific resource types in your own
+	// code and don't use this catch all struct, you show know which resource
+	// type you are expecting and handle that type only.
+	//
+	// Every resource struct type should be unique for every combination of
+	// "resource_type"/"resource_version" combination of the Event type /
+	// webhook message.
 	Resource struct {
-		// Payment Resource type
 		ID                        string                     `json:"id,omitempty"`
 		Status                    string                     `json:"status,omitempty"`
 		StatusDetails             *CaptureStatusDetails      `json:"status_details,omitempty"`


### PR DESCRIPTION
#### What does this PR do?
- Reformat earlier deprecation comments so they are compatible with docs rendering (I hope)
- Deprecate the Resource struct (reasons outlined here https://github.com/plutov/paypal/pull/205#issuecomment-879721101 )
 
