### PR TITLE
Update payment source type for optional fields

### DIFF
--- a/types.go
+++ b/types.go
@@ -767,8 +767,8 @@ type (
 
 	// PaymentSource structure
 	PaymentSource struct {
-		Card  *PaymentSourceCard  `json:"card,omitempty"`
-		Token *PaymentSourceToken `json:"token,omitempty"`
+		Card  *PaymentSourceCard  `json:"card"`
+		Token *PaymentSourceToken `json:"token"`
 	}
 
 	// PaymentSourceCard structure

--- a/types.go
+++ b/types.go
@@ -767,8 +767,8 @@ type (
 
 	// PaymentSource structure
 	PaymentSource struct {
-		Card  *PaymentSourceCard  `json:"card"`
-		Token *PaymentSourceToken `json:"token"`
+		Card  *PaymentSourceCard  `json:"card,omitempty"`
+		Token *PaymentSourceToken `json:"token,omitempty"`
 	}
 
 	// PaymentSourceCard structure


### PR DESCRIPTION
#### What does this PR do?

Adds "omitempty" clause to the optional fields in PaymentSource type.

#### Where should the reviewer start?

Two lines changed

#### How should this be manually tested?

All tests still passing

#### Any background context you want to provide?

Documentation [here](https://developer.paypal.com/docs/api/orders/v2/#definition-payment_source)