### PR TITLE
feat: Correct create order ApplicationContext type

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,15 +173,12 @@ order, err := c.GetOrder("O-4J082351X3132253H")
 
 ```go
 purchaseUnit := paypal.PurchaseUnitRequest{ReferenceID: "ref-id", Amount: paypal.Amount{Total: "7.00", Currency: "USD"}}
-appContext := paypal.ApplicationContext{
-	ShippingPreference: paypal.ShippingPreferenceNoShipping,
-	UserAction:         paypal.UserActionPayNow,
-	LandingPage:        paypal.LandingPageLogin,
-	PaymentMethod: paypal.PaymentMethod{
-		PayeePreferred:         paypal.PayeePreferredImmediatePaymentRequired,
-		StandardEntryClassCode: paypal.StandardEntryClassCodeWeb,
-	},
-	ReturnURL: "https://example.com/return-url",
+appContext := paypal.OrderApplicationContext{
+    ShippingPreference: paypal.ShippingPreferenceNoShipping,
+    UserAction:         paypal.UserActionPayNow,
+    LandingPage:        paypal.LandingPageLogin,
+    ReturnURL:          "https://example.com/return-url",
+    CancelURL:          "https://example.com/cancel-url",
 }
 order, err := c.CreateOrder(ctx, paypal.OrderIntentCapture, []paypal.PurchaseUnitRequest{purchaseUnit}, nil, &appContext)
 ```

--- a/README.md
+++ b/README.md
@@ -172,7 +172,18 @@ order, err := c.GetOrder("O-4J082351X3132253H")
 ### Create an Order
 
 ```go
-order, err := c.CreateOrder(paypal.OrderIntentCapture, []paypal.PurchaseUnitRequest{paypal.PurchaseUnitRequest{ReferenceID: "ref-id", Amount: paypal.Amount{Total: "7.00", Currency: "USD"}}})
+purchaseUnit := paypal.PurchaseUnitRequest{ReferenceID: "ref-id", Amount: paypal.Amount{Total: "7.00", Currency: "USD"}}
+appContext := paypal.ApplicationContext{
+	ShippingPreference: paypal.ShippingPreferenceNoShipping,
+	UserAction:         paypal.UserActionPayNow,
+	LandingPage:        paypal.LandingPageLogin,
+	PaymentMethod: paypal.PaymentMethod{
+		PayeePreferred:         paypal.PayeePreferredImmediatePaymentRequired,
+		StandardEntryClassCode: paypal.StandardEntryClassCodeWeb,
+	},
+	ReturnURL: "https://example.com/return-url",
+}
+order, err := c.CreateOrder(ctx, paypal.OrderIntentCapture, []paypal.PurchaseUnitRequest{purchaseUnit}, nil, &appContext)
 ```
 
 ### Update Order by ID

--- a/const.go
+++ b/const.go
@@ -37,6 +37,14 @@ const (
 	SetupFeeFailureActionCancel   SetupFeeFailureAction = "CANCEL"
 )
 
+type LandingPage string
+
+const (
+	LandingPageLogin        LandingPage = "LOGIN"
+	LandingPageBilling      LandingPage = "BILLING"
+	LandingPageNoPreference LandingPage = "NO_PREFERENCE"
+)
+
 type ShippingPreference string
 
 const (
@@ -52,6 +60,22 @@ const (
 	UserActionPayNow   UserAction = "PAY_NOW"
 )
 
+type PayeePreferred string
+
+const (
+	PayeePreferredUnrestricted             PayeePreferred = "UNRESTRICTED"
+	PayeePreferredImmediatePaymentRequired PayeePreferred = "IMMEDIATE_PAYMENT_REQUIRED"
+)
+
+type StandardEntryClassCode string
+
+const (
+	StandardEntryClassCodeTel StandardEntryClassCode = "TEL"
+	StandardEntryClassCodeWeb StandardEntryClassCode = "WEB"
+	StandardEntryClassCodeCCD StandardEntryClassCode = "CCD"
+	StandardEntryClassCodePPD StandardEntryClassCode = "PPD"
+)
+
 type SubscriptionStatus string
 
 const (
@@ -63,7 +87,7 @@ const (
 	SubscriptionStatusExpired         SubscriptionStatus = "EXPIRED"
 )
 
-//Doc: https://developer.paypal.com/docs/api/subscriptions/v1/#definition-transaction
+// Doc: https://developer.paypal.com/docs/api/subscriptions/v1/#definition-transaction
 type SubscriptionTransactionStatus string
 
 const (
@@ -81,7 +105,7 @@ const (
 )
 
 type ProductType string
-type ProductCategory string //Doc: https://developer.paypal.com/docs/api/catalog-products/v1/#definition-product_category
+type ProductCategory string // Doc: https://developer.paypal.com/docs/api/catalog-products/v1/#definition-product_category
 const (
 	ProductTypePhysical ProductType = "PHYSICAL"
 	ProductTypeDigital  ProductType = "DIGITAL"

--- a/order.go
+++ b/order.go
@@ -24,7 +24,7 @@ func (c *Client) GetOrder(ctx context.Context, orderID string) (*Order, error) {
 
 // CreateOrder - Use this call to create an order
 // Endpoint: POST /v2/checkout/orders
-func (c *Client) CreateOrder(ctx context.Context, intent string, purchaseUnits []PurchaseUnitRequest, payer *CreateOrderPayer, appContext *ApplicationContext) (*Order, error) {
+func (c *Client) CreateOrder(ctx context.Context, intent string, purchaseUnits []PurchaseUnitRequest, payer *CreateOrderPayer, appContext *OrderApplicationContext) (*Order, error) {
 	return c.CreateOrderWithPaypalRequestID(ctx, intent, purchaseUnits, payer, appContext, "")
 }
 
@@ -34,14 +34,14 @@ func (c *Client) CreateOrderWithPaypalRequestID(ctx context.Context,
 	intent string,
 	purchaseUnits []PurchaseUnitRequest,
 	payer *CreateOrderPayer,
-	appContext *ApplicationContext,
+	appContext *OrderApplicationContext,
 	requestID string,
 ) (*Order, error) {
 	type createOrderRequest struct {
-		Intent             string                `json:"intent"`
-		Payer              *CreateOrderPayer     `json:"payer,omitempty"`
-		PurchaseUnits      []PurchaseUnitRequest `json:"purchase_units"`
-		ApplicationContext *ApplicationContext   `json:"application_context,omitempty"`
+		Intent             string                   `json:"intent"`
+		Payer              *CreateOrderPayer        `json:"payer,omitempty"`
+		PurchaseUnits      []PurchaseUnitRequest    `json:"purchase_units"`
+		ApplicationContext *OrderApplicationContext `json:"application_context,omitempty"`
 	}
 
 	order := &Order{}
@@ -161,7 +161,7 @@ func (c *Client) RefundCaptureWithPaypalRequestId(ctx context.Context,
 
 // CapturedDetail - https://developer.paypal.com/docs/api/payments/v2/#captures_get
 // Endpoint: GET /v2/payments/captures/ID
-func (c *Client) CapturedDetail(ctx context.Context, captureID string ) (*CaptureDetailsResponse, error) {
+func (c *Client) CapturedDetail(ctx context.Context, captureID string) (*CaptureDetailsResponse, error) {
 	response := &CaptureDetailsResponse{}
 
 	req, err := c.NewRequest(ctx, "GET", fmt.Sprintf("%s%s", c.APIBase, "/v2/payments/captures/"+captureID), nil)

--- a/types.go
+++ b/types.go
@@ -210,15 +210,9 @@ type (
 		LandingPage        LandingPage        `json:"landing_page,omitempty"`
 		ShippingPreference ShippingPreference `json:"shipping_preference,omitempty"`
 		UserAction         UserAction         `json:"user_action,omitempty"`
-		PaymentMethod      *PaymentMethod     `json:"payment_method"`
 		ReturnURL          string             `json:"return_url,omitempty"`
 		CancelURL          string             `json:"cancel_url,omitempty"`
-	}
-
-	PaymentMethod struct {
-		PayerSelected          string                 `json:"payer_selected"`
-		PayeePreferred         PayeePreferred         `json:"payee_preferred"`
-		StandardEntryClassCode StandardEntryClassCode `json:"standard_entry_class_code"`
+		// TODO: add missing fields PaymentMethod and StoredPaymentSource
 	}
 
 	// Authorization struct

--- a/types.go
+++ b/types.go
@@ -192,15 +192,33 @@ type (
 	}
 
 	// ApplicationContext struct
-	//Doc: https://developer.paypal.com/docs/api/subscriptions/v1/#definition-application_context
+	// Doc: https://developer.paypal.com/docs/api/subscriptions/v1/#definition-application_context
 	ApplicationContext struct {
 		BrandName          string             `json:"brand_name,omitempty"`
 		Locale             string             `json:"locale,omitempty"`
 		ShippingPreference ShippingPreference `json:"shipping_preference,omitempty"`
 		UserAction         UserAction         `json:"user_action,omitempty"`
-		//LandingPage        string `json:"landing_page,omitempty"` // not found in documentation
-		ReturnURL string `json:"return_url,omitempty"`
-		CancelURL string `json:"cancel_url,omitempty"`
+		ReturnURL          string             `json:"return_url,omitempty"`
+		CancelURL          string             `json:"cancel_url,omitempty"`
+	}
+
+	// OrderApplicationContext struct
+	// Doc: https://developer.paypal.com/docs/api/orders/v2/#definition-order_application_context
+	OrderApplicationContext struct {
+		BrandName          string             `json:"brand_name,omitempty"`
+		Locale             string             `json:"locale,omitempty"`
+		LandingPage        LandingPage        `json:"landing_page,omitempty"`
+		ShippingPreference ShippingPreference `json:"shipping_preference,omitempty"`
+		UserAction         UserAction         `json:"user_action,omitempty"`
+		PaymentMethod      *PaymentMethod     `json:"payment_method"`
+		ReturnURL          string             `json:"return_url,omitempty"`
+		CancelURL          string             `json:"cancel_url,omitempty"`
+	}
+
+	PaymentMethod struct {
+		PayerSelected          string                 `json:"payer_selected"`
+		PayeePreferred         PayeePreferred         `json:"payee_preferred"`
+		StandardEntryClassCode StandardEntryClassCode `json:"standard_entry_class_code"`
 	}
 
 	// Authorization struct
@@ -277,7 +295,7 @@ type (
 		Links            []Link                `json:"links,omitempty"`
 	}
 
-	//https://developer.paypal.com/docs/api/payments/v2/#captures_get
+	// https://developer.paypal.com/docs/api/payments/v2/#captures_get
 	CaptureDetailsResponse struct {
 		Status                    string                     `json:"status,omitempty"`
 		StatusDetails             *CaptureStatusDetails      `json:"status_details,omitempty"`
@@ -929,7 +947,7 @@ type (
 		SenderBatchID string `json:"sender_batch_id,omitempty"`
 	}
 
-	//ShippingAmount struct
+	// ShippingAmount struct
 	ShippingAmount struct {
 		Money
 	}
@@ -958,7 +976,7 @@ type (
 	}
 
 	// Name struct
-	//Doc: https://developer.paypal.com/docs/api/subscriptions/v1/#definition-name
+	// Doc: https://developer.paypal.com/docs/api/subscriptions/v1/#definition-name
 	Name struct {
 		FullName   string `json:"full_name,omitempty"`
 		Suffix     string `json:"suffix,omitempty"`
@@ -1006,7 +1024,7 @@ type (
 		Payee            *Payee          `json:"payee,omitempty"`
 	}
 
-	//Payee struct
+	// Payee struct
 	Payee struct {
 		Email string `json:"email"`
 	}
@@ -1327,9 +1345,9 @@ type (
 	}
 
 	ListParams struct {
-		Page          string `json:"page,omitempty"`           //Default: 0.
-		PageSize      string `json:"page_size,omitempty"`      //Default: 10.
-		TotalRequired string `json:"total_required,omitempty"` //Default: no.
+		Page          string `json:"page,omitempty"`           // Default: 0.
+		PageSize      string `json:"page_size,omitempty"`      // Default: 10.
+		TotalRequired string `json:"total_required,omitempty"` // Default: no.
 	}
 
 	SharedListResponse struct {


### PR DESCRIPTION
The ApplicationContext type used in POST /v2/checkout/orders is not the
same as ApplicationContext used elsewhere. This change forks the
ApplicationContext type, and adds some missing fields to the new
OrderApplicationContext.

Also updated the CreateOrder example in README.md.
