### PR TITLE
Add cancel billing agreement function

### DIFF
--- a/billing_agreements.go
+++ b/billing_agreements.go
@@ -7,7 +7,20 @@ import (
 
 // CreatePaypalBillingAgreementToken - Use this call to create a billing agreement token
 // Endpoint: POST /v1/billing-agreements/agreement-tokens
+// Deprecated: use CreateBillingAgreementToken instead
 func (c *Client) CreatePaypalBillingAgreementToken(
+	ctx context.Context,
+	description *string,
+	shippingAddress *ShippingAddress,
+	payer *Payer,
+	plan *BillingPlan,
+) (*BillingAgreementToken, error) {
+	return c.CreateBillingAgreementToken(ctx, description, shippingAddress, payer, plan)
+}
+
+// CreateBillingAgreementToken - Use this call to create a billing agreement token
+// Endpoint: POST /v1/billing-agreements/agreement-tokens
+func (c *Client) CreateBillingAgreementToken(
 	ctx context.Context,
 	description *string,
 	shippingAddress *ShippingAddress,
@@ -41,7 +54,17 @@ func (c *Client) CreatePaypalBillingAgreementToken(
 
 // CreatePaypalBillingAgreementFromToken - Use this call to create a billing agreement
 // Endpoint: POST /v1/billing-agreements/agreements
+// Deprecated: use CreateBillingAgreementFromToken instead
 func (c *Client) CreatePaypalBillingAgreementFromToken(
+	ctx context.Context,
+	tokenID string,
+) (*BillingAgreementFromToken, error) {
+	return c.CreateBillingAgreementFromToken(ctx, tokenID)
+}
+
+// CreateBillingAgreementFromToken - Use this call to create a billing agreement
+// Endpoint: POST /v1/billing-agreements/agreements
+func (c *Client) CreateBillingAgreementFromToken(
 	ctx context.Context,
 	tokenID string,
 ) (*BillingAgreementFromToken, error) {
@@ -67,9 +90,9 @@ func (c *Client) CreatePaypalBillingAgreementFromToken(
 	return billingAgreement, nil
 }
 
-// CancelPaypalBillingAgreement - Use this call to cancel a billing agreement
+// CancelBillingAgreement - Use this call to cancel a billing agreement
 // Endpoint: POST /v1/billing-agreements/agreements/{agreement_id}/cancel
-func (c *Client) CancelPaypalBillingAgreement(
+func (c *Client) CancelBillingAgreement(
 	ctx context.Context,
 	billingAgreementID string,
 ) error {

--- a/billing_agreements.go
+++ b/billing_agreements.go
@@ -68,21 +68,18 @@ func (c *Client) CreatePaypalBillingAgreementFromToken(
 }
 
 // CancelPaypalBillingAgreement - Use this call to cancel a billing agreement
-// Endpoint: POST /v1/payments/billing-agreements/{agreement_id}/cancel
+// Endpoint: POST /v1/billing-agreements/agreements/{agreement_id}/cancel
 func (c *Client) CancelPaypalBillingAgreement(
 	ctx context.Context,
 	billingAgreementID string,
-	note string,
 ) error {
-	type createBARequest struct {
-		note string `json:"note"`
-	}
+	type cancelBARequest struct{}
 
 	req, err := c.NewRequest(
 		ctx,
 		"POST",
 		fmt.Sprintf("%s%s%s%s", c.APIBase, "/v1/billing-agreements/agreements/", billingAgreementID, "/cancel"),
-		createBARequest{note})
+		cancelBARequest{})
 	if err != nil {
 		return err
 	}

--- a/billing_agreements.go
+++ b/billing_agreements.go
@@ -66,3 +66,30 @@ func (c *Client) CreatePaypalBillingAgreementFromToken(
 
 	return billingAgreement, nil
 }
+
+// CancelPaypalBillingAgreement - Use this call to cancel a billing agreement
+// Endpoint: POST /v1/payments/billing-agreements/{agreement_id}/cancel
+func (c *Client) CancelPaypalBillingAgreement(
+	ctx context.Context,
+	billingAgreementID string,
+	note string,
+) error {
+	type createBARequest struct {
+		note string `json:"note"`
+	}
+
+	req, err := c.NewRequest(
+		ctx,
+		"POST",
+		fmt.Sprintf("%s%s%s%s", c.APIBase, "/v1/billing-agreements/agreements/", billingAgreementID, "/cancel"),
+		createBARequest{note})
+	if err != nil {
+		return err
+	}
+
+	if err = c.SendWithAuth(req, nil); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/unit_test.go
+++ b/unit_test.go
@@ -883,7 +883,7 @@ func TestDeleteWebProfile_invalid(t *testing.T) {
 
 }
 
-func TestCreatePaypalBillingAgreementToken(t *testing.T) {
+func TestCreateBillingAgreementToken(t *testing.T) {
 
 	ts := httptest.NewServer(&webprofileTestServer{t: t})
 	defer ts.Close()
@@ -891,7 +891,7 @@ func TestCreatePaypalBillingAgreementToken(t *testing.T) {
 	c, _ := NewClient("foo", "bar", ts.URL)
 	description := "name A"
 
-	_, err := c.CreatePaypalBillingAgreementToken(
+	_, err := c.CreateBillingAgreementToken(
 		context.Background(),
 		&description,
 		&ShippingAddress{RecipientName: "Name", Type: "Type", Line1: "Line1", Line2: "Line2"},
@@ -904,28 +904,28 @@ func TestCreatePaypalBillingAgreementToken(t *testing.T) {
 
 }
 
-func TestCreatePaypalBillingAgreementFromToken(t *testing.T) {
+func TestCreateBillingAgreementFromToken(t *testing.T) {
 
 	ts := httptest.NewServer(&webprofileTestServer{t: t})
 	defer ts.Close()
 
 	c, _ := NewClient("foo", "bar", ts.URL)
 
-	_, err := c.CreatePaypalBillingAgreementFromToken(context.Background(), "BillingAgreementToken")
+	_, err := c.CreateBillingAgreementFromToken(context.Background(), "BillingAgreementToken")
 
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestCancelPaypalBillingAgreement(t *testing.T) {
+func TestCancelBillingAgreement(t *testing.T) {
 
 	ts := httptest.NewServer(&webprofileTestServer{t: t})
 	defer ts.Close()
 
 	c, _ := NewClient("foo", "bar", ts.URL)
 
-	err := c.CancelPaypalBillingAgreement(context.Background(), testBillingAgreementID)
+	err := c.CancelBillingAgreement(context.Background(), testBillingAgreementID)
 
 	if err != nil {
 		t.Fatal(err)

--- a/unit_test.go
+++ b/unit_test.go
@@ -925,7 +925,7 @@ func TestCancelPaypalBillingAgreement(t *testing.T) {
 
 	c, _ := NewClient("foo", "bar", ts.URL)
 
-	err := c.CancelPaypalBillingAgreement(context.Background(), testBillingAgreementID, "test")
+	err := c.CancelPaypalBillingAgreement(context.Background(), testBillingAgreementID)
 
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
#### What does this PR do?
Adds function to allow users to cancel billing agreements with the id and a note (reason)
#### Where should the reviewer start?
The function is just hitting the cancel endpoint with an id
#### How should this be manually tested?
The function is hitting the endpoint with an id, there is a unit test as well
#### Any background context you want to provide?
follow api at https://developer.paypal.com/docs/limited-release/reference-transactions/#cancel-billing-agreement