### PR TITLE
Added missing `items` on `PurchaseUnit` struct

### DIFF
--- a/types.go
+++ b/types.go
@@ -591,6 +591,7 @@ type (
 		ID                 string              `json:"id,omitempty"`
 		SoftDescriptor     string              `json:"soft_descriptor,omitempty"`
 		Shipping           *ShippingDetail     `json:"shipping,omitempty"`
+		Items              []Item              `json:"items,omitempty"`
 	}
 
 	// TaxInfo used for orders.


### PR DESCRIPTION
When you call `GetOrder()` paypal also returns the items for `purchase_unit` ref: [https://developer.paypal.com/docs/api/orders/v2/#definition-purchase_unit](https://developer.paypal.com/docs/api/orders/v2/#definition-purchase_unit)

The `PurchaseUnit` struct was missing the `Items` key/parameter.