### PR TITLE
Update ReAuthorization call parameters

### DIFF
--- a/authorization.go
+++ b/authorization.go
@@ -71,7 +71,7 @@ func (c *Client) VoidAuthorization(ctx context.Context, authID string) (*Authori
 // PayPal recommends reauthorizing payment after ~3 days
 // Endpoint: POST /v2/payments/authorizations/ID/reauthorize
 func (c *Client) ReauthorizeAuthorization(ctx context.Context, authID string, a *Amount) (*Authorization, error) {
-	buf := bytes.NewBuffer([]byte(`{"amount":{"currency_code":"` + a.Currency + `","total":"` + a.Total + `"}}`))
+	buf := bytes.NewBuffer([]byte(`{"amount":{"currency_code":"` + a.Currency + `","value":"` + a.Total + `"}}`))
 	req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("%s%s", c.APIBase, "/v2/payments/authorizations/"+authID+"/reauthorize"), buf)
 	auth := &Authorization{}
 


### PR DESCRIPTION
#### What does this PR do?
Updates reauthorization call parameters to make them in line with the [Paypal docs](https://developer.paypal.com/docs/api/payments/v2/#authorizations_reauthorize).]

This issue was found here #219 