### PR TITLE
Add status field to CaptureAmount

### DIFF
--- a/types.go
+++ b/types.go
@@ -686,6 +686,7 @@ type (
 
 	// CaptureAmount struct
 	CaptureAmount struct {
+		Status                    string                     `json:"status,omitempty"`
 		ID                        string                     `json:"id,omitempty"`
 		CustomID                  string                     `json:"custom_id,omitempty"`
 		Amount                    *PurchaseUnitAmount        `json:"amount,omitempty"`


### PR DESCRIPTION
Add status field to CaptureAmount, as defined in the Paypal specification:
https://developer.paypal.com/docs/api/orders/v2/#definition-capture