### PR TITLE
Missing plan override

### DIFF
--- a/subscription.go
+++ b/subscription.go
@@ -18,6 +18,7 @@ type (
 		AutoRenewal        bool                `json:"auto_renewal,omitempty"`
 		ApplicationContext *ApplicationContext `json:"application_context,omitempty"`
 		CustomID           string              `json:"custom_id,omitempty"`
+		Plan               *PlanOverride       `json:"plan,omitempty"`
 	}
 
 	SubscriptionDetails struct {
@@ -72,6 +73,34 @@ type (
 		Note        string      `json:"note"`
 		CaptureType CaptureType `json:"capture_type"`
 		Amount      Money       `json:"amount"`
+	}
+
+	// https://developer.paypal.com/docs/api/subscriptions/v1/#definition-plan_override
+	PlanOverride struct {
+		BillingCycles      []BillingCycleOverride       `json:"billing_cycles,omitempty"`
+		PaymentPreferences *PaymentPreferencesOverride `json:"payment_preferences,omitempty"`
+		Taxes              *TaxesOverride              `json:"taxes,omitempty"`
+	}
+
+	// https://developer.paypal.com/docs/api/subscriptions/v1/#definition-payment_preferences_override
+	PaymentPreferencesOverride struct {
+		AutoBillOutstanding     bool                  `json:"auto_bill_outstanding,omitempty"`
+		SetupFee                Money                 `json:"setup_fee,omitempty"`
+		SetupFeeFailureAction   SetupFeeFailureAction `json:"setup_fee_failure_action,omitempty"`
+		PaymentFailureThreshold int                   `json:"payment_failure_threshold,omitempty"`
+	}
+
+	// https://developer.paypal.com/docs/api/subscriptions/v1/#definition-payment_preferences_override
+	TaxesOverride struct {
+		Percentage string `json:"percentage,omitempty"`
+		Inclusive  *bool  `json:"inclusive,omitempty"`
+	}
+
+	// https://developer.paypal.com/docs/api/subscriptions/v1/#definition-billing_cycle_override
+	BillingCycleOverride struct {
+		PricingScheme PricingScheme `json:"pricing_scheme,omitempty"`
+		Sequence      *int          `json:"sequence,omitempty"`
+		TotalCycles   *int          `json:"total_cycles,omitempty"`
 	}
 )
 


### PR DESCRIPTION
PayPal API now accepts also the "plan override" - useful for discounts or taxes changes. In the code, only two methods use the `SubscriptionBase`, and both in Paypal API have the plan override field:

https://developer.paypal.com/docs/api/subscriptions/v1/#subscriptions_create
https://developer.paypal.com/docs/api/subscriptions/v1/#subscriptions_revise