### PR TITLE
Potential fix for Issue 230

### DIFF
--- a/webhooks.go
+++ b/webhooks.go
@@ -97,7 +97,7 @@ func (c *Client) VerifyWebhookSignature(ctx context.Context, httpReq *http.Reque
 	var bodyBytes []byte
 	if httpReq.Body != nil {
 		bodyBytes, _ = ioutil.ReadAll(httpReq.Body)
-	}else{
+	} else {
 		return nil, errors.New("Cannot verify webhook for HTTP Request with empty body.")
 	}
 	// Restore the io.ReadCloser to its original state

--- a/webhooks.go
+++ b/webhooks.go
@@ -97,8 +97,7 @@ func (c *Client) VerifyWebhookSignature(ctx context.Context, httpReq *http.Reque
 	var bodyBytes []byte
 	if httpReq.Body != nil {
 		bodyBytes, _ = ioutil.ReadAll(httpReq.Body)
-	}
-	else{
+	}else{
 		return nil, errors.New("Cannot verify webhook for HTTP Request with empty body.")
 	}
 	// Restore the io.ReadCloser to its original state

--- a/webhooks.go
+++ b/webhooks.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -89,13 +90,16 @@ func (c *Client) VerifyWebhookSignature(ctx context.Context, httpReq *http.Reque
 		TransmissionSig  string          `json:"transmission_sig,omitempty"`
 		TransmissionTime string          `json:"transmission_time,omitempty"`
 		WebhookID        string          `json:"webhook_id,omitempty"`
-		Event            json.RawMessage `json:"webhook_event"`
+		Event            json.RawMessage `json:"webhook_event,omitempty"`
 	}
 
 	// Read the content
 	var bodyBytes []byte
 	if httpReq.Body != nil {
 		bodyBytes, _ = ioutil.ReadAll(httpReq.Body)
+	}
+	else{
+		return nil, errors.New("Cannot verify webhook for HTTP Request with empty body.")
 	}
 	// Restore the io.ReadCloser to its original state
 	httpReq.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))


### PR DESCRIPTION
#### What does this PR do?
`VerifyWebhookSignature` now returns an error if an *http.Request with an empty body is passed.

#### Where should the reviewer start?
Only a few lines were added to `webhooks.go`. Feel free to write new unit tests for `VerifyWebhookSignature`.

#### How should this be manually tested?
`c.VerifyWebhookSignature` should be passed an *http.Request  with an empty body.

#### Any background context you want to provide?
Issue #230
