### PR TITLE
Added PayPal-Mock-Response for capture

### DIFF
--- a/order.go
+++ b/order.go
@@ -2,6 +2,7 @@ package paypal
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
@@ -99,7 +100,7 @@ func (c *Client) AuthorizeOrder(ctx context.Context, orderID string, authorizeOr
 // CaptureOrder - https://developer.paypal.com/docs/api/orders/v2/#orders_capture
 // Endpoint: POST /v2/checkout/orders/ID/capture
 func (c *Client) CaptureOrder(ctx context.Context, orderID string, captureOrderRequest CaptureOrderRequest) (*CaptureOrderResponse, error) {
-	return c.CaptureOrderWithPaypalRequestId(ctx, orderID, captureOrderRequest, "")
+	return c.CaptureOrderWithPaypalRequestId(ctx, orderID, captureOrderRequest, "", nil)
 }
 
 // CaptureOrder with idempotency - https://developer.paypal.com/docs/api/orders/v2/#orders_capture
@@ -109,6 +110,7 @@ func (c *Client) CaptureOrderWithPaypalRequestId(ctx context.Context,
 	orderID string,
 	captureOrderRequest CaptureOrderRequest,
 	requestID string,
+	mockResponse *CaptureOrderMockResponse,
 ) (*CaptureOrderResponse, error) {
 	capture := &CaptureOrderResponse{}
 
@@ -120,6 +122,15 @@ func (c *Client) CaptureOrderWithPaypalRequestId(ctx context.Context,
 
 	if requestID != "" {
 		req.Header.Set("PayPal-Request-Id", requestID)
+	}
+
+	if mockResponse != nil {
+		mock, err := json.Marshal(mockResponse)
+		if err != nil {
+			return nil, err
+		}
+
+		req.Header.Set("PayPal-Mock-Response", string(mock))
 	}
 
 	if err = c.SendWithAuth(req, capture); err != nil {

--- a/types.go
+++ b/types.go
@@ -299,6 +299,11 @@ type (
 		PaymentSource *PaymentSource `json:"payment_source"`
 	}
 
+	// CaptureOrderMockResponse - https://developer.paypal.com/docs/api-basics/sandbox/request-headers/#test-api-error-handling-routines
+	CaptureOrderMockResponse struct {
+		MockApplicationCodes string `json:"mock_application_codes"`
+	}
+
 	// RefundOrderRequest - https://developer.paypal.com/docs/api/payments/v2/#captures_refund
 	RefundCaptureRequest struct {
 		Amount      *Money `json:"amount,omitempty"`


### PR DESCRIPTION
#### What does this PR do?
Adds support to mock responses for paypal capture in 

#### Where should the reviewer start?
Test errors with https://developer.paypal.com/docs/platforms/checkout/add-capabilities/handle-funding-failures/#1-modify-code

#### How should this be manually tested?
Add the new parameter as provided above and try to receive different error messages in sandbox

#### Any background context you want to provide?
We wanted to test different error behaviours, so we needed to add the header for it.
https://developer.paypal.com/docs/platforms/checkout/add-capabilities/handle-funding-failures/#1-modify-code