### PR TITLE
Adding PaymentMethod support into ApplicationContext

### DIFF
--- a/const.go
+++ b/const.go
@@ -102,3 +102,17 @@ const (
 	ProductCategorySoftwareOther                             ProductCategory = "OTHER"
 	ProductCategorySoftwareServices                          ProductCategory = "SERVICES"
 )
+
+type PayeePreferred string // Doc: https://developer.paypal.com/api/orders/v2/#definition-payment_method
+const (
+	PayeePreferredUnrestricted 					PayeePreferred = "UNRESTRICTED"
+	PayeePreferredImmediatePaymentRequired 		PayeePreferred = "IMMEDIATE_PAYMENT_REQUIRED"
+)
+
+type StandardEntryClassCode string // Doc: https://developer.paypal.com/api/orders/v2/#definition-payment_method
+const (
+	StandardEntryClassCodeTel					StandardEntryClassCode="TEL"
+	StandardEntryClassCodeWeb					StandardEntryClassCode="WEB"
+	StandardEntryClassCodeCcd					StandardEntryClassCode="CCD"
+	StandardEntryClassCodePpd					StandardEntryClassCode="PPD"
+)

--- a/const.go
+++ b/const.go
@@ -105,7 +105,7 @@ const (
 
 type PayeePreferred string // Doc: https://developer.paypal.com/api/orders/v2/#definition-payment_method
 const (
-	PayeePreferredUnrestricted 								PayeePreferred = "UNRESTRICTED"
+	PayeePreferredUnrestricted 						PayeePreferred = "UNRESTRICTED"
 	PayeePreferredImmediatePaymentRequired 					PayeePreferred = "IMMEDIATE_PAYMENT_REQUIRED"
 )
 

--- a/const.go
+++ b/const.go
@@ -105,8 +105,8 @@ const (
 
 type PayeePreferred string // Doc: https://developer.paypal.com/api/orders/v2/#definition-payment_method
 const (
-	PayeePreferredUnrestricted 					PayeePreferred = "UNRESTRICTED"
-	PayeePreferredImmediatePaymentRequired 		PayeePreferred = "IMMEDIATE_PAYMENT_REQUIRED"
+	PayeePreferredUnrestricted 								PayeePreferred = "UNRESTRICTED"
+	PayeePreferredImmediatePaymentRequired 					PayeePreferred = "IMMEDIATE_PAYMENT_REQUIRED"
 )
 
 type StandardEntryClassCode string // Doc: https://developer.paypal.com/api/orders/v2/#definition-payment_method

--- a/types.go
+++ b/types.go
@@ -198,7 +198,7 @@ type (
 		Locale             string             `json:"locale,omitempty"`
 		ShippingPreference ShippingPreference `json:"shipping_preference,omitempty"`
 		UserAction         UserAction         `json:"user_action,omitempty"`
-		PaymentMethod	   PaymentMethod	  `json:"payment_method,omitempty"`
+		PaymentMethod	   PaymentMethod      `json:"payment_method,omitempty"`
 		//LandingPage        string `json:"landing_page,omitempty"` // not found in documentation
 		ReturnURL string `json:"return_url,omitempty"`
 		CancelURL string `json:"cancel_url,omitempty"`
@@ -207,7 +207,7 @@ type (
 	// Doc: https://developer.paypal.com/api/orders/v2/#definition-payment_method
 	PaymentMethod struct {
 		PayeePreferred	  		PayeePreferred      	`json:"payee_preferred,omitempty"`
-		StandardEntryClassCode	StandardEntryClassCode  `json:"standard_entry_class_code,omitempty"`
+		StandardEntryClassCode	        StandardEntryClassCode  `json:"standard_entry_class_code,omitempty"`
 	}
 
 	// Authorization struct

--- a/types.go
+++ b/types.go
@@ -198,9 +198,16 @@ type (
 		Locale             string             `json:"locale,omitempty"`
 		ShippingPreference ShippingPreference `json:"shipping_preference,omitempty"`
 		UserAction         UserAction         `json:"user_action,omitempty"`
+		PaymentMethod	   PaymentMethod	  `json:"payment_method,omitempty"`
 		//LandingPage        string `json:"landing_page,omitempty"` // not found in documentation
 		ReturnURL string `json:"return_url,omitempty"`
 		CancelURL string `json:"cancel_url,omitempty"`
+	}
+
+	// Doc: https://developer.paypal.com/api/orders/v2/#definition-payment_method
+	PaymentMethod struct {
+		PayeePreferred	  		PayeePreferred      	`json:"payee_preferred,omitempty"`
+		StandardEntryClassCode	StandardEntryClassCode  `json:"standard_entry_class_code,omitempty"`
 	}
 
 	// Authorization struct


### PR DESCRIPTION
#### What does this PR do?
Adds support for payment_method field in order application_context

https://developer.paypal.com/api/orders/v2/#definition-order_application_context
https://developer.paypal.com/api/orders/v2/#definition-payment_method

#### Where should the reviewer start?
ApplicationContext

#### How should this be manually tested?
Ensure fields are added correctly into ApplicationContext

#### Any background context you want to provide?
Want to provide support for payee_preferred field in payment_methods in order to specify required immediate payments