### PR TITLE
add sale_id field to Refund struct

### DIFF
--- a/types.go
+++ b/types.go
@@ -898,6 +898,7 @@ type (
 		CaptureID     string     `json:"capture_id,omitempty"`
 		ParentPayment string     `json:"parent_payment,omitempty"`
 		UpdateTime    *time.Time `json:"update_time,omitempty"`
+		SaleID        string     `json:"sale_id,omitempty"`
 	}
 
 	// RefundResponse .


### PR DESCRIPTION
#### What does this PR do?

The `sale_id` field is provided when a refund on a sale is performed. I noticed this field existed in a Refund object when receiving a `PAYMENT.SALE.REFUNDED` webhook message. Here's an example generated by the webhook simulator:

```json
{
  "id": "WH-2N242548W9943490U-1JU23391CS4765624",
  "create_time": "2014-10-31T15:42:24Z",
  "resource_type": "sale",
  "event_type": "PAYMENT.SALE.REFUNDED",
  "summary": "A 0.01 USD sale payment was refunded",
  "resource": {
    "sale_id": "9T0916710M1105906",
    "parent_payment": "PAY-5437236047802405NKRJ22UA",
    "update_time": "2014-10-31T15:41:51Z",
    "amount": {
      "total": "-0.01",
      "currency": "USD"
    },
    "create_time": "2014-10-31T15:41:51Z",
    "links": [
      {
        "href": "https://api.paypal.com/v1/payments/refund/6YX43824R4443062K",
        "rel": "self",
        "method": "GET"
      },
      {
        "href": "https://api.paypal.com/v1/payments/payment/PAY-5437236047802405NKRJ22UA",
        "rel": "parent_payment",
        "method": "GET"
      },
      {
        "href": "https://api.paypal.com/v1/payments/sale/9T0916710M1105906",
        "rel": "sale",
        "method": "GET"
      }
    ],
    "id": "6YX43824R4443062K",
    "state": "completed"
  },
  "links": [
    {
      "href": "https://api.paypal.com/v1/notifications/webhooks-events/WH-2N242548W9943490U-1JU23391CS4765624",
      "rel": "self",
      "method": "GET",
      "encType": "application/json"
    },
    {
      "href": "https://api.paypal.com/v1/notifications/webhooks-events/WH-2N242548W9943490U-1JU23391CS4765624/resend",
      "rel": "resend",
      "method": "POST",
      "encType": "application/json"
    }
  ],
  "event_version": "1.0"
}
```