### PR TITLE
add payer_id field to Subscriber struct

### DIFF
--- a/types.go
+++ b/types.go
@@ -198,7 +198,7 @@ type (
 		Locale             string             `json:"locale,omitempty"`
 		ShippingPreference ShippingPreference `json:"shipping_preference,omitempty"`
 		UserAction         UserAction         `json:"user_action,omitempty"`
-		PaymentMethod	   PaymentMethod      `json:"payment_method,omitempty"`
+		PaymentMethod      PaymentMethod      `json:"payment_method,omitempty"`
 		//LandingPage        string `json:"landing_page,omitempty"` // not found in documentation
 		ReturnURL string `json:"return_url,omitempty"`
 		CancelURL string `json:"cancel_url,omitempty"`
@@ -206,8 +206,8 @@ type (
 
 	// Doc: https://developer.paypal.com/api/orders/v2/#definition-payment_method
 	PaymentMethod struct {
-		PayeePreferred	  		PayeePreferred      	`json:"payee_preferred,omitempty"`
-		StandardEntryClassCode	        StandardEntryClassCode  `json:"standard_entry_class_code,omitempty"`
+		PayeePreferred         PayeePreferred         `json:"payee_preferred,omitempty"`
+		StandardEntryClassCode StandardEntryClassCode `json:"standard_entry_class_code,omitempty"`
 	}
 
 	// Authorization struct
@@ -990,6 +990,7 @@ type (
 
 	// Subscriber struct
 	Subscriber struct {
+		PayerID         string               `json:"payer_id"`
 		ShippingAddress ShippingDetail       `json:"shipping_address,omitempty"`
 		Name            CreateOrderPayerName `json:"name,omitempty"`
 		EmailAddress    string               `json:"email_address,omitempty"`


### PR DESCRIPTION
This field was missing; see paypal API docs: https://developer.paypal.com/docs/api/subscriptions/v1/#definition-subscriber

Other changes are a product of `gofmt`