### PR TITLE
fix update order patchrequest

### DIFF
--- a/order.go
+++ b/order.go
@@ -72,14 +72,19 @@ func (c *Client) UpdateOrder(ctx context.Context, orderID string, op string, pat
 		Path  string            `json:"path"`
 		Value map[string]string `json:"value"`
 	}
-	order := &Order{}
 
-	req, err := c.NewRequest(ctx, "PATCH", fmt.Sprintf("%s%s%s", c.APIBase, "/v2/checkout/orders/", orderID), patchRequest{Op: op, Path: path, Value: value})
+	req, err := c.NewRequest(ctx, "PATCH", fmt.Sprintf("%s%s%s", c.APIBase, "/v2/checkout/orders/", orderID), []patchRequest{
+		{
+			Op:    op,
+			Path:  path,
+			Value: value,
+		},
+	})
 	if err != nil {
 		return err
 	}
 
-	if err = c.SendWithAuth(req, order); err != nil {
+	if err = c.SendWithAuth(req, nil); err != nil {
 		return err
 	}
 	return nil

--- a/order_test.go
+++ b/order_test.go
@@ -1,0 +1,66 @@
+package paypal
+
+import (
+	"context"
+	"testing"
+)
+
+var testClientID = "AXy9orp-CDaHhBZ9C78QHW2BKZpACgroqo85_NIOa9mIfJ9QnSVKzY-X_rivR_fTUUr6aLjcJsj6sDur"
+var testSecret = "EBoIiUSkCKeSk49hHSgTem1qnjzzJgRQHDEHvGpzlLEf_nIoJd91xu8rPOBDCdR_UYNKVxJE-UgS2iCw"
+
+func TestUpdateOrder(t *testing.T) {
+	ctx := context.Background()
+
+	c, _ := NewClient(testClientID, testSecret, APIBaseSandBox)
+	_, _ = c.GetAccessToken(ctx)
+
+	orderResponse, err := c.CreateOrder(
+		ctx,
+		OrderIntentCapture,
+		[]PurchaseUnitRequest{
+			{
+				Amount: &PurchaseUnitAmount{
+					Value:    "7.00",
+					Currency: "USD",
+				},
+			},
+		},
+		&CreateOrderPayer{},
+		&ApplicationContext{},
+	)
+	if err != nil {
+		t.Errorf("Not expected error for CreateOrder(), got %s", err.Error())
+	}
+
+	order, err := c.GetOrder(ctx, orderResponse.ID)
+	if err != nil {
+		t.Errorf("Not expected error for GetOrder(), got %s", err.Error())
+	}
+
+	if order.PurchaseUnits[0].Amount.Value != "7.00" {
+		t.Errorf("CreateOrder amount incorrect")
+	}
+
+	err = c.UpdateOrder(
+		ctx,
+		orderResponse.ID,
+		"replace",
+		"/purchase_units/@reference_id=='default'/amount",
+		map[string]string{
+			"currency_code": "USD",
+			"value":         "2.00",
+		},
+	)
+	if err != nil {
+		t.Errorf("Not expected error for UpdateOrder(), got %s", err.Error())
+	}
+
+	order, err = c.GetOrder(ctx, orderResponse.ID)
+	if err != nil {
+		t.Errorf("Not expected error for GetOrder(), got %s", err.Error())
+	}
+
+	if order.PurchaseUnits[0].Amount.Value != "2.00" {
+		t.Errorf("CreateOrder after update amount incorrect")
+	}
+}


### PR DESCRIPTION
#### What does this PR do?
changes body in UpdateOrder to be an array as per the api 
https://developer.paypal.com/docs/api/orders/v2/#orders_patch
```
[
  {
    "op": "replace",
    "path": "/purchase_units/@reference_id=='default'/amount",
    "value": {
      "currency_code": "USD",
      "value": "2.00"
    }
  }
]
```

although the way it is it is only takes the params for a single operation, it could be changed to handle batch operation but that would require more changes wanted to get feedback first ?

would need to be something like 
```
c.UpdateOrder(
	ctx, 
        OrderID,
	paypal.PatchRequest[]{
		{
			Op: "replace",
			Path:  "/purchase_units/@reference_id=='default'/amount",
			Value: 	map[string]string{
				"currency_code": "USD",
				"value":         "2.00",
			},
		},
		{
			Op: "replace",
			Path:  "/purchase_units/@reference_id=='default'/shipping/address",
			Value: 	map[string]string{
				"address_line_1": "123 Townsend St",
				"address_line_2": "Floor 6",
				"admin_area_2": "San Francisco",
				"admin_area_1": "CA",
				"postal_code": "94107",
				"country_code": "US"
			},
		}
	}
}
``` 

patch call response also doesn't contain a body so changed it form `order` to `nil`


#### Where should the reviewer start?
#### How should this be manually tested?
#### Any background context you want to provide?