### PR TITLE
feat: Add missing fields into ErrorResponseDetail

### DIFF
--- a/types.go
+++ b/types.go
@@ -495,9 +495,11 @@ type (
 
 	// ErrorResponseDetail struct
 	ErrorResponseDetail struct {
-		Field string `json:"field"`
-		Issue string `json:"issue"`
-		Links []Link `json:"link"`
+		Field   string `json:"field"`
+		Issue   string `json:"issue"`
+		Name    string `json:"name"`
+		Message string `json:"message"`
+		Links   []Link `json:"link"`
 	}
 
 	// ErrorResponse https://developer.paypal.com/docs/api/errors/

--- a/unit_test.go
+++ b/unit_test.go
@@ -144,6 +144,35 @@ func TestTypeErrorResponseTwo(t *testing.T) {
 	}
 }
 
+func TestTypeErrorResponseThree(t *testing.T) {
+	response := `{
+		"name": "BUSINESS_ERROR",
+		"debug_id": "[REDACTED]",
+		"message": "Business error",
+		"information_link": "https://developer.paypal.com/webapps/developer/docs/api/#BUSINESS_ERROR",
+		"details": [
+			{
+				"name": "TOKEN_NOT_FOUND",
+				"message": "Not Found: Invalid BA-Token Identifier"
+			}
+		]
+	}`
+
+	i := &ErrorResponse{}
+	err := json.Unmarshal([]byte(response), i)
+	if err != nil {
+		t.Errorf("ErrorResponse Unmarshal failed")
+	}
+
+	if i.Name != "BUSINESS_ERROR" ||
+		i.Message != "Business error" ||
+		len(i.Details) != 1 ||
+		i.Details[0].Name != "TOKEN_NOT_FOUND" ||
+		i.Details[0].Message != "Not Found: Invalid BA-Token Identifier" {
+		t.Errorf("ErrorResponse decoded result is incorrect, Given: %v", i)
+	}
+}
+
 func TestTypePayoutResponse(t *testing.T) {
 	response := `{
 		"batch_header":{


### PR DESCRIPTION
#### What does this PR do?
This PR adds `name` and `message` fields into ErrorResponseDetail struct.

#### Where should the reviewer start?
types.go

#### How should this be manually tested?
Unmarshal an example response below using the ErrorResponse struct.

#### Any background context you want to provide?
These fields are not documented anywhere in the official documentation yet, but actually exists in an errored response:

```json
{
  "name": "BUSINESS_ERROR",
  "debug_id": "[REDACTED]",
  "message": "Business error",
  "information_link": "https://developer.paypal.com/webapps/developer/docs/api/#BUSINESS_ERROR",
  "details": [
    {
      "name": "TOKEN_NOT_FOUND",
      "message": "Not Found: Invalid BA-Token Identifier"
    }
  ]
}
```
