### PR TITLE
Adds the ToDuration function to the expirationTime type

### DIFF
--- a/types.go
+++ b/types.go
@@ -1649,3 +1649,9 @@ func (e *expirationTime) UnmarshalJSON(b []byte) error {
 	*e = expirationTime(i)
 	return nil
 }
+
+// Convert ExpirationTime to time.Duration
+func (e *expirationTime) ToDuration() time.Duration {
+    seconds := int64(*e)
+    return time.Duration(seconds) * time.Second
+}


### PR DESCRIPTION
What does this PR do?
Adds the ToDuration function to the expirationTime type. This function allows easy conversion of the internal value to a time. Duration type, which is crucial when using expirationTime values with Redis expiration times.

Where should the reviewer start?
types.go

How should this be manually tested?
Try to add an access token and expiration time to Redis. 