### PR TITLE
Added url and image_url for a item

### DIFF
--- a/types.go
+++ b/types.go
@@ -782,6 +782,8 @@ type (
 		Description string `json:"description,omitempty"`
 		SKU         string `json:"sku,omitempty"`
 		Category    string `json:"category,omitempty"`
+		URL         string `json:"url,omitempty"`
+		ImageURL    string `json:"image_url,omitempty"`
 	}
 
 	// ItemList struct


### PR DESCRIPTION
#### What does this PR do?
Added missing fields to a type
#### Where should the reviewer start?
comparing my change with paypal docs. I already triple checked it but feel free to check it again.
docs: https://developer.paypal.com/docs/api/orders/v2/#orders_create
#### How should this be manually tested?
By using those fields on a create order request
#### Any background context you want to provide?
When using CreateOrder we have PurchaseUnitRequest inside it a list of Items, according to paypal docs
this item can have a url, and a image_url

url:
The URL to the item being purchased. Visible to buyer and used in buyer experiences.

image_url:
The URL of the item's image.