### PR TITLE
fix: err response body read cuase body empty

### DIFF
--- a/client.go
+++ b/client.go
@@ -120,7 +120,11 @@ func (c *Client) Send(req *http.Request, v interface{}) error {
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		errResp := &ErrorResponse{Response: resp}
-		data, err = io.ReadAll(resp.Body)
+
+		var bodyBuffer bytes.Buffer
+		teeReader := io.TeeReader(resp.Body, &bodyBuffer)
+		data, err = io.ReadAll(teeReader)
+		resp.Body = io.NopCloser(&bodyBuffer)
 
 		if err == nil && len(data) > 0 {
 			err := json.Unmarshal(data, errResp)


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the issue where reading the entire request body using `io.ReadAll` (or similar methods) causes the request body to be exhausted and unavailable for subsequent reads. The solution involves replacing the request body with a new `io.Reader` that contains the previously read data, allowing it to be read multiple times.
#### Where should the reviewer start?
Reviewers should start by examining the changes made to the code where the request body is read. Specifically, look at the implementation of the logic that replaces the request body with a new io.Reader after reading it. This is typically done using io.NopCloser and bytes.NewBuffer.
#### How should this be manually tested?
use add track info api. use invalid transaction id
#### Any background context you want to provide?
In Go, reading from an io.Reader (such as http.Request.Body) consumes the data, making it unavailable for subsequent reads. This can be problematic when you need to inspect or process the request body multiple times. The standard library does not provide a built-in way to reset the reader, so this PR implements a workaround by caching the read data and reusing it.
This approach ensures that the request body can be read multiple times without causing issues, which is particularly useful in scenarios involving middleware or when the request body needs to be processed by multiple handlers.