### PR TITLE
Corrected typo in CapturedPayments

### DIFF
--- a/types.go
+++ b/types.go
@@ -944,8 +944,8 @@ type (
 
 	// CapturedPayments has the amounts for a captured order
 	CapturedPayments struct {
-		Autthorizations []Authorization `json:"authorizations,omitempty"`
-		Captures        []CaptureAmount `json:"captures,omitempty"`
+		Authorizations []Authorization `json:"authorizations,omitempty"`
+		Captures       []CaptureAmount `json:"captures,omitempty"`
 	}
 
 	// CapturedPurchaseItem are items for a captured order


### PR DESCRIPTION
#### What does this PR do?
Corrects the name of the `Autthorizations` field in `CapturedPayments` struct to remove the typo.
#### Where should the reviewer start?
Trivial change.
#### How should this be manually tested?
This typo exists only on the field name, which isn't used anywhere else in the codebase and shouldn't affect (de)serialization.
Maybe only testing the actual API call just-in-case.
#### Any background context you want to provide?
This likely should be considered a breaking change for consumers, so perhaps warrants to be included in the next minor release rather than patch?