### PR TITLE
feat:add disputes apis

### DIFF
--- a/dispute.go
+++ b/dispute.go
@@ -1,0 +1,430 @@
+package paypal
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+type ListDisputesRequest struct {
+	StartTime             *time.Time
+	DisputedTransactionId *string
+	PageSize              *int
+	NextPageToken         *string
+	DisputeState          *string
+	UpdateTimeBefore      *time.Time
+	UpdateTimeAfter       *time.Time
+}
+
+type ListDisputesResponse struct {
+	Items []*DisputeItem `json:"items,omitempty"`
+	Links []Link         `json:"links,omitempty"`
+}
+
+type DisputeItem struct {
+	DisputeID             string                     `json:"dispute_id,omitempty"`
+	CreateTime            time.Time                  `json:"create_time,omitempty"`
+	UpdateTime            time.Time                  `json:"update_time,omitempty"`
+	DisputedTransactions  []*DisputedTransactionItem `json:"disputed_transactions,omitempty"`
+	Reason                string                     `json:"reason,omitempty"`
+	Status                string                     `json:"status,omitempty"`
+	DisputeState          DisputeState               `json:"dispute_state,omitempty"`
+	DisputeAmount         *Money                     `json:"dispute_amount,omitempty"`
+	Outcome               string                     `json:"outcome,omitempty"`
+	DisputeLifeCycleStage string                     `json:"dispute_life_cycle_stage,omitempty"`
+	DisputeChannel        string                     `json:"dispute_channel,omitempty"`
+	DisputeFlow           string                     `json:"dispute_flow,omitempty"`
+	Links                 []Link                     `json:"links,omitempty"`
+}
+
+type DisputedTransactionItem struct {
+	BuyerTransactionID string `json:"buyer_transaction_id,omitempty"`
+	Buyer              Buyer  `json:"buyer,omitempty"`
+	Seller             Seller `json:"seller,omitempty"`
+}
+
+type Buyer struct {
+	PayerID string `json:"payer_id,omitempty"`
+	Name    string `json:"name,omitempty"`
+}
+
+type Seller struct {
+	Email      string `json:"email,omitempty"`
+	MerchantID string `json:"merchant_id,omitempty"`
+	Name       string `json:"name,omitempty"`
+}
+
+type GetDisputeDetailResponse struct {
+	DisputeID             string                       `json:"dispute_id,omitempty"`
+	CreateTime            time.Time                    `json:"create_time,omitempty"`
+	UpdateTime            time.Time                    `json:"update_time,omitempty"`
+	DisputedTransactions  []*DisputedTransactionDetail `json:"disputed_transactions,omitempty"`
+	Reason                string                       `json:"reason,omitempty"`
+	Status                string                       `json:"status,omitempty"`
+	DisputeAmount         *Money                       `json:"dispute_amount,omitempty"`
+	DisputeOutcome        *DisputeOutcome              `json:"dispute_outcome,omitempty"`
+	DisputeLifeCycleStage string                       `json:"dispute_life_cycle_stage,omitempty"`
+	DisputeChannel        string                       `json:"dispute_channel,omitempty"`
+	Messages              []*Message                   `json:"messages,omitempty"`
+	Extensions            *Extensions                  `json:"extensions,omitempty"`
+	Offer                 *Offer                       `json:"offer,omitempty"`
+	Links                 []Link                       `json:"links,omitempty"`
+}
+
+type DisputeOutcome struct {
+	OutcomeCode    string `json:"outcome_code,omitempty"`
+	AmountRefunded *Money `json:"amount_refunded,omitempty"`
+}
+
+type DisputedTransactionDetail struct {
+	SellerTransactionID string    `json:"seller_transaction_id,omitempty"`
+	CreateTime          time.Time `json:"create_time,omitempty"`
+	TransactionStatus   string    `json:"transaction_status,omitempty"`
+	GrossAmount         *Money    `json:"gross_amount,omitempty"`
+	Buyer               Buyer     `json:"buyer,omitempty"`
+	Seller              Seller    `json:"seller,omitempty"`
+}
+
+type Extensions struct {
+	MerchandizeDisputeProperties MerchandizeDisputeProperties `json:"merchandize_dispute_properties,omitempty"`
+}
+
+type MerchandizeDisputeProperties struct {
+	IssueType      string          `json:"issue_type,omitempty"`
+	ServiceDetails *ServiceDetails `json:"service_details,omitempty"`
+}
+
+type ServiceDetails struct {
+	SubReasons  []string `json:"sub_reasons,omitempty"`
+	PurchaseURL string   `json:"purchase_url,omitempty"`
+}
+
+type Message struct {
+	PostedBy   string      `json:"posted_by,omitempty"`
+	TimePosted time.Time   `json:"time_posted,omitempty"`
+	Content    string      `json:"content,omitempty"`
+	Documents  []*Document `json:"documents,omitempty"`
+}
+
+type Document struct {
+	Name string `json:"name,omitempty"`
+	URL  string `json:"url,omitempty"`
+}
+
+type Offer struct {
+	BuyerRequestedAmount *Money     `json:"buyer_requested_amount,omitempty"`
+	OfferType            string     `json:"offer_type,omitempty"`
+	History              []*History `json:"history,omitempty"`
+}
+
+type History struct {
+	OfferTime             time.Time `json:"offer_time,omitempty"`
+	Actor                 string    `json:"actor,omitempty"`
+	EventType             string    `json:"event_type,omitempty"`
+	OfferType             string    `json:"offer_type,omitempty"`
+	OfferAmount           *Money    `json:"offer_amount,omitempty"`
+	Notes                 string    `json:"notes,omitempty"`
+	DisputeLifeCycleStage string    `json:"dispute_life_cycle_stage,omitempty"`
+}
+
+type UpdateDisputeValue struct {
+	ID         string    `json:"id,omitempty"`
+	Name       string    `json:"name,omitempty"`
+	CreateTime time.Time `json:"create_time,omitempty"`
+	Reason     string    `json:"reason,omitempty"`
+	Status     string    `json:"status,omitempty"`
+}
+
+type UpdateDisputeParams struct {
+	Op    string              `json:"op,omitempty"`
+	Path  string              `json:"path,omitempty"`
+	Value *UpdateDisputeValue `json:"value,omitempty"`
+}
+
+type DisputeAcceptClaimParams struct {
+	Note                  string                 `json:"note,omitempty"`
+	AcceptClaimReason     AcceptClaimReason      `json:"accept_claim_reason,omitempty"`
+	InvoiceId             string                 `json:"invoice_id,omitempty"`
+	RefundAmount          *Money                 `json:"refund_amount,omitempty"`
+	ReturnShippingAddress *ReturnShippingAddress `json:"return_shipping_address,omitempty"`
+	ReturnShipmentInfo    []*ReturnShipmentInfo  `json:"return_shipment_info,omitempty"`
+	AcceptClaimType       AcceptClaimType        `json:"accept_claim_type,omitempty"`
+}
+
+type ReturnShipmentInfo struct {
+	ShipmentLabel *ShipmentLabel `json:"shipment_label"`
+	TrackingInfo  *TrackingInfo  `json:"tracking_info"`
+}
+
+type ShipmentLabel struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type TrackingInfo struct {
+	CarrierName      string `json:"carrier_name,omitempty"`
+	TrackingNumber   string `json:"tracking_number,omitempty"`
+	CarrierNameOther string `json:"carrier_name_other,omitempty"`
+	TrackingUrl      string `json:"tracking_url,omitempty"`
+}
+
+type ReturnShippingAddress struct {
+	AddressLine1 string `json:"address_line_1,omitempty"`
+	AddressLine2 string `json:"address_line_2,omitempty"`
+	CountryCode  string `json:"country_code,omitempty"`
+	AdminArea1   string `json:"admin_area_1,omitempty"`
+	AdminArea2   string `json:"admin_area_2,omitempty"`
+	PostalCode   string `json:"postal_code,omitempty"`
+}
+
+type DisputeMakeOfferParams struct {
+	Note                  string                 `json:"note,omitempty"`
+	InvoiceId             string                 `json:"invoice_id,omitempty"`
+	OfferAmount           *Money                 `json:"offer_amount,omitempty"`
+	ReturnShippingAddress *ReturnShippingAddress `json:"return_shipping_address,omitempty"`
+	OfferType             MakeOfferType          `json:"offer_type,omitempty"`
+}
+
+type DisputeAcknowledgeReturnItemParams struct {
+	Note      string             `json:"note,omitempty"`
+	Evidences []*DisputeEvidence `json:"evidences,omitempty"`
+}
+
+type DisputeEvidence struct {
+	EvidenceType EvidenceType         `json:"evidence_type,omitempty"`
+	Documents    []*Document          `json:"documents,omitempty"`
+	Notes        string               `json:"notes,omitempty"`
+	ItemId       string               `json:"item_id,omitempty"`
+	EvidenceInfo *DisputeEvidenceInfo `json:"evidence_info,omitempty"`
+}
+
+type DisputeEvidenceInfo struct {
+	TrackingInfo []*TrackingInfo `json:"tracking_info,omitempty"`
+	RefundIds    []string        `json:"refund_ids,omitempty"`
+}
+
+type DisputeProvideEvidenceParams struct {
+	Evidences             *DisputeEvidence       `json:"evidences,omitempty"`
+	ReturnShippingAddress *ReturnShippingAddress `json:"return_shipping_address,omitempty"`
+}
+
+type DisputeAppealParams struct {
+	Evidences             *DisputeEvidence       `json:"evidences,omitempty"`
+	ReturnShippingAddress *ReturnShippingAddress `json:"return_shipping_address,omitempty"`
+}
+
+// ListDisputes - Lists disputes with a summary set of details.
+// Endpoint: GET /v1/customer/disputes
+// https://developer.paypal.com/docs/api/customer-disputes/v1/#disputes_list
+func (c *Client) ListDisputes(ctx context.Context, req *ListDisputesRequest) (*ListDisputesResponse, error) {
+	response := &ListDisputesResponse{}
+
+	r, err := c.NewRequest(ctx, "GET", fmt.Sprintf("%s%s", c.APIBase, "/v1/customer/disputes"), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	q := r.URL.Query()
+
+	if req.StartTime != nil {
+		q.Add("start_time", req.StartTime.Format(time.RFC3339))
+	}
+	if req.DisputedTransactionId != nil {
+		q.Add("disputed_transactioniId", *req.DisputedTransactionId)
+	}
+	if req.PageSize != nil {
+		q.Add("page_size", strconv.Itoa(*req.PageSize))
+	}
+	if req.NextPageToken != nil {
+		q.Add("next_page_token", *req.NextPageToken)
+	}
+	if req.DisputeState != nil {
+		q.Add("dispute_state", *req.DisputeState)
+	}
+	if req.UpdateTimeBefore != nil {
+		q.Add("update_time_before", req.UpdateTimeBefore.Format(time.RFC3339))
+	}
+	if req.UpdateTimeAfter != nil {
+		q.Add("update_time_after", req.UpdateTimeAfter.Format(time.RFC3339))
+	}
+
+	r.URL.RawQuery = q.Encode()
+
+	if err = c.SendWithAuth(r, response); err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+// Shows details for a dispute, by ID
+// Endpoint: GET /v1/customer/disputes/{dispute_id}
+// https://developer.paypal.com/docs/api/customer-disputes/v1/#disputes_get
+func (c *Client) GetDisputeDetail(ctx context.Context, DisputeID string) (*GetDisputeDetailResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/v1/customer/disputes/%s", c.APIBase, DisputeID), nil)
+	response := &GetDisputeDetailResponse{}
+	if err != nil {
+		return response, err
+	}
+	err = c.SendWithAuth(req, response)
+	return response, err
+}
+
+// Partially updates a dispute, by ID
+// Endpoint: PATCH /v1/customer/disputes/{id}
+// https://developer.paypal.com/docs/api/customer-disputes/v1/#disputes_patch
+func (c *Client) UpdateDispute(ctx context.Context, disputeId string, params *UpdateDisputeParams) error {
+	req, err := c.NewRequest(ctx, http.MethodPatch, fmt.Sprintf("%s%s%s", c.APIBase, "/v1/customer/disputes/", disputeId), params)
+	if err != nil {
+		return err
+	}
+	err = c.SendWithAuth(req, nil)
+	return err
+}
+
+// Provides evidence for a dispute, by ID
+// Endpoint: POST /v1/customer/disputes/{id}/provide-evidence
+// https://developer.paypal.com/docs/api/customer-disputes/v1/#disputes_provide-evidence
+func (c *Client) DisputeProvideEvidence(ctx context.Context, disputeId string, params *DisputeProvideEvidenceParams) error {
+	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s%s%s/provide-evidence", c.APIBase, "/v1/customer/disputes/", disputeId), params)
+	if err != nil {
+		return err
+	}
+	err = c.SendWithAuth(req, nil)
+	return err
+}
+
+// Appeals a dispute, by ID
+// Endpoint: POST /v1/customer/disputes/{id}/appeal
+// https://developer.paypal.com/docs/api/customer-disputes/v1/#disputes_appeal
+func (c *Client) DisputeAppeal(ctx context.Context, disputeId string, params *DisputeAppealParams) error {
+	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s%s%s/appeal", c.APIBase, "/v1/customer/disputes/", disputeId), params)
+	if err != nil {
+		return err
+	}
+	err = c.SendWithAuth(req, nil)
+	return err
+}
+
+// Accepts liability for a claim, by ID
+// Endpoint: POST /v1/customer/disputes/{id}/accept-claim
+// https://developer.paypal.com/docs/api/customer-disputes/v1/#disputes_accept-claim
+func (c *Client) DisputeAcceptClaim(ctx context.Context, disputeId string, params *DisputeAcceptClaimParams) error {
+	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s%s%s/accept-claim", c.APIBase, "/v1/customer/disputes/", disputeId), params)
+	if err != nil {
+		return err
+	}
+	err = c.SendWithAuth(req, nil)
+	return err
+}
+
+// Settles a dispute in either the customer's or merchant's favor.
+// Endpoint: POST /v1/customer/disputes/{id}/adjudicate
+// https://developer.paypal.com/docs/api/customer-disputes/v1/#disputes_adjudicate
+func (c *Client) SettleDispute(ctx context.Context, disputeId string, adjudicateOutcome AdjudicationOutcome) error {
+	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s%s%s/adjudicate", c.APIBase, "/v1/customer/disputes/", disputeId), map[string]string{"adjudication_outcome": string(adjudicateOutcome)})
+	if err != nil {
+		return err
+	}
+	err = c.SendWithAuth(req, nil)
+	return err
+}
+
+// Updates the status of a dispute, by ID
+// Endpoint: POST /v1/customer/disputes/{id}/require-evidence
+// https://developer.paypal.com/docs/api/customer-disputes/v1/#disputes_require-evidence
+// Important: This method is for sandbox use only.
+func (c *Client) DisputeUpdateStatus(ctx context.Context, disputeId string, adjudicateOutcome AdjudicationOutcome) error {
+	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s%s%s/require-evidence", c.APIBase, "/v1/customer/disputes/", disputeId), map[string]string{"action": string(adjudicateOutcome)})
+	if err != nil {
+		return err
+	}
+	err = c.SendWithAuth(req, nil)
+	return err
+}
+
+// Escalates the dispute, by ID
+// Endpoint: POST /v1/customer/disputes/{id}/escalate
+// https://developer.paypal.com/docs/api/customer-disputes/v1/#disputes_escalate
+func (c *Client) DisputeEscalateToClaim(ctx context.Context, disputeId string, note string) error {
+	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s%s%s/escalate", c.APIBase, "/v1/customer/disputes/", disputeId), map[string]string{"note": note})
+	if err != nil {
+		return err
+	}
+	err = c.SendWithAuth(req, nil)
+	return err
+}
+
+// Sends a message about a dispute, by ID, to the other party in the dispute.
+// Endpoint: POST /v1/customer/disputes/{id}/send-message
+// https://developer.paypal.com/docs/api/customer-disputes/v1/#disputes_send-message
+func (c *Client) DisputeSendMessageToOtherParty(ctx context.Context, disputeId string, message string) error {
+	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s%s%s/send-message", c.APIBase, "/v1/customer/disputes/", disputeId), map[string]string{"message": message})
+	if err != nil {
+		return err
+	}
+	err = c.SendWithAuth(req, nil)
+	return err
+}
+
+// Makes an offer to the other party to resolve a dispute, by ID
+// Endpoint: POST /v1/customer/disputes/{id}/make-offer
+// https://developer.paypal.com/docs/api/customer-disputes/v1/#disputes_make-offer
+func (c *Client) DisputeMakeOffer(ctx context.Context, disputeId string, params *DisputeMakeOfferParams) error {
+	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s%s%s/make-offer", c.APIBase, "/v1/customer/disputes/", disputeId), params)
+	if err != nil {
+		return err
+	}
+	err = c.SendWithAuth(req, nil)
+	return err
+}
+
+// The customer accepts the offer from merchant to resolve a dispute, by ID
+// Endpoint: POST /v1/customer/disputes/{id}/accept-offer
+// https://developer.paypal.com/docs/api/customer-disputes/v1/#disputes_accept-offer
+func (c *Client) DisputeAcceptOffer(ctx context.Context, disputeId string, note string) error {
+	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s%s%s/accept-offer", c.APIBase, "/v1/customer/disputes/", disputeId), map[string]string{"note": note})
+	if err != nil {
+		return err
+	}
+	err = c.SendWithAuth(req, nil)
+	return err
+}
+
+// Denies an offer that the merchant proposes for a dispute, by ID.
+// Endpoint: POST /v1/customer/disputes/{id}/deny-offer
+// https://developer.paypal.com/docs/api/customer-disputes/v1/#disputes_deny-offer
+func (c *Client) DisputeDenyOffer(ctx context.Context, disputeId string, note string) error {
+	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s%s%s/deny-offer", c.APIBase, "/v1/customer/disputes/", disputeId), map[string]string{"note": note})
+	if err != nil {
+		return err
+	}
+	err = c.SendWithAuth(req, nil)
+	return err
+}
+
+// Acknowledges that the customer returned an item for a dispute, by ID.
+// Endpoint: POST /v1/customer/disputes/{id}/acknowledge-return-item
+// https://developer.paypal.com/docs/api/customer-disputes/v1/#disputes_acknowledge-return-item
+func (c *Client) DisputeAcknowledgeReturnItem(ctx context.Context, disputeId string, params *DisputeAcknowledgeReturnItemParams) error {
+	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s%s%s/acknowledge-return-item", c.APIBase, "/v1/customer/disputes/", disputeId), params)
+	if err != nil {
+		return err
+	}
+	err = c.SendWithAuth(req, nil)
+	return err
+}
+
+// Provides supporting information for a dispute, by ID.
+// Endpoint: POST /v1/customer/disputes/{id}/provide-supporting-info
+// https://developer.paypal.com/docs/api/customer-disputes/v1/#disputes_provide-supporting-info
+func (c *Client) DisputeProvideSupportingInfo(ctx context.Context, disputeId string, notes string) error {
+	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s%s%s/provide-supporting-info", c.APIBase, "/v1/customer/disputes/", disputeId), map[string]string{"notes": notes})
+	if err != nil {
+		return err
+	}
+	err = c.SendWithAuth(req, nil)
+	return err
+}

--- a/dispute.go
+++ b/dispute.go
@@ -8,220 +8,13 @@ import (
 	"time"
 )
 
-type ListDisputesRequest struct {
-	StartTime             *time.Time
-	DisputedTransactionId *string
-	PageSize              *int
-	NextPageToken         *string
-	DisputeState          *string
-	UpdateTimeBefore      *time.Time
-	UpdateTimeAfter       *time.Time
-}
-
-type ListDisputesResponse struct {
-	Items []*DisputeItem `json:"items,omitempty"`
-	Links []Link         `json:"links,omitempty"`
-}
-
-type DisputeItem struct {
-	DisputeID             string                     `json:"dispute_id,omitempty"`
-	CreateTime            time.Time                  `json:"create_time,omitempty"`
-	UpdateTime            time.Time                  `json:"update_time,omitempty"`
-	DisputedTransactions  []*DisputedTransactionItem `json:"disputed_transactions,omitempty"`
-	Reason                string                     `json:"reason,omitempty"`
-	Status                string                     `json:"status,omitempty"`
-	DisputeState          DisputeState               `json:"dispute_state,omitempty"`
-	DisputeAmount         *Money                     `json:"dispute_amount,omitempty"`
-	Outcome               string                     `json:"outcome,omitempty"`
-	DisputeLifeCycleStage string                     `json:"dispute_life_cycle_stage,omitempty"`
-	DisputeChannel        string                     `json:"dispute_channel,omitempty"`
-	DisputeFlow           string                     `json:"dispute_flow,omitempty"`
-	Links                 []Link                     `json:"links,omitempty"`
-}
-
-type DisputedTransactionItem struct {
-	BuyerTransactionID string `json:"buyer_transaction_id,omitempty"`
-	Buyer              Buyer  `json:"buyer,omitempty"`
-	Seller             Seller `json:"seller,omitempty"`
-}
-
-type Buyer struct {
-	PayerID string `json:"payer_id,omitempty"`
-	Name    string `json:"name,omitempty"`
-}
-
-type Seller struct {
-	Email      string `json:"email,omitempty"`
-	MerchantID string `json:"merchant_id,omitempty"`
-	Name       string `json:"name,omitempty"`
-}
-
-type GetDisputeDetailResponse struct {
-	DisputeID             string                       `json:"dispute_id,omitempty"`
-	CreateTime            time.Time                    `json:"create_time,omitempty"`
-	UpdateTime            time.Time                    `json:"update_time,omitempty"`
-	DisputedTransactions  []*DisputedTransactionDetail `json:"disputed_transactions,omitempty"`
-	Reason                string                       `json:"reason,omitempty"`
-	Status                string                       `json:"status,omitempty"`
-	DisputeAmount         *Money                       `json:"dispute_amount,omitempty"`
-	DisputeOutcome        *DisputeOutcome              `json:"dispute_outcome,omitempty"`
-	DisputeLifeCycleStage string                       `json:"dispute_life_cycle_stage,omitempty"`
-	DisputeChannel        string                       `json:"dispute_channel,omitempty"`
-	Messages              []*Message                   `json:"messages,omitempty"`
-	Extensions            *Extensions                  `json:"extensions,omitempty"`
-	Offer                 *Offer                       `json:"offer,omitempty"`
-	Links                 []Link                       `json:"links,omitempty"`
-}
-
-type DisputeOutcome struct {
-	OutcomeCode    string `json:"outcome_code,omitempty"`
-	AmountRefunded *Money `json:"amount_refunded,omitempty"`
-}
-
-type DisputedTransactionDetail struct {
-	SellerTransactionID string    `json:"seller_transaction_id,omitempty"`
-	CreateTime          time.Time `json:"create_time,omitempty"`
-	TransactionStatus   string    `json:"transaction_status,omitempty"`
-	GrossAmount         *Money    `json:"gross_amount,omitempty"`
-	Buyer               Buyer     `json:"buyer,omitempty"`
-	Seller              Seller    `json:"seller,omitempty"`
-}
-
-type Extensions struct {
-	MerchandizeDisputeProperties MerchandizeDisputeProperties `json:"merchandize_dispute_properties,omitempty"`
-}
-
-type MerchandizeDisputeProperties struct {
-	IssueType      string          `json:"issue_type,omitempty"`
-	ServiceDetails *ServiceDetails `json:"service_details,omitempty"`
-}
-
-type ServiceDetails struct {
-	SubReasons  []string `json:"sub_reasons,omitempty"`
-	PurchaseURL string   `json:"purchase_url,omitempty"`
-}
-
-type Message struct {
-	PostedBy   string      `json:"posted_by,omitempty"`
-	TimePosted time.Time   `json:"time_posted,omitempty"`
-	Content    string      `json:"content,omitempty"`
-	Documents  []*Document `json:"documents,omitempty"`
-}
-
-type Document struct {
-	Name string `json:"name,omitempty"`
-	URL  string `json:"url,omitempty"`
-}
-
-type Offer struct {
-	BuyerRequestedAmount *Money     `json:"buyer_requested_amount,omitempty"`
-	OfferType            string     `json:"offer_type,omitempty"`
-	History              []*History `json:"history,omitempty"`
-}
-
-type History struct {
-	OfferTime             time.Time `json:"offer_time,omitempty"`
-	Actor                 string    `json:"actor,omitempty"`
-	EventType             string    `json:"event_type,omitempty"`
-	OfferType             string    `json:"offer_type,omitempty"`
-	OfferAmount           *Money    `json:"offer_amount,omitempty"`
-	Notes                 string    `json:"notes,omitempty"`
-	DisputeLifeCycleStage string    `json:"dispute_life_cycle_stage,omitempty"`
-}
-
-type UpdateDisputeValue struct {
-	ID         string    `json:"id,omitempty"`
-	Name       string    `json:"name,omitempty"`
-	CreateTime time.Time `json:"create_time,omitempty"`
-	Reason     string    `json:"reason,omitempty"`
-	Status     string    `json:"status,omitempty"`
-}
-
-type UpdateDisputeParams struct {
-	Op    string              `json:"op,omitempty"`
-	Path  string              `json:"path,omitempty"`
-	Value *UpdateDisputeValue `json:"value,omitempty"`
-}
-
-type DisputeAcceptClaimParams struct {
-	Note                  string                 `json:"note,omitempty"`
-	AcceptClaimReason     AcceptClaimReason      `json:"accept_claim_reason,omitempty"`
-	InvoiceId             string                 `json:"invoice_id,omitempty"`
-	RefundAmount          *Money                 `json:"refund_amount,omitempty"`
-	ReturnShippingAddress *ReturnShippingAddress `json:"return_shipping_address,omitempty"`
-	ReturnShipmentInfo    []*ReturnShipmentInfo  `json:"return_shipment_info,omitempty"`
-	AcceptClaimType       AcceptClaimType        `json:"accept_claim_type,omitempty"`
-}
-
-type ReturnShipmentInfo struct {
-	ShipmentLabel *ShipmentLabel `json:"shipment_label"`
-	TrackingInfo  *TrackingInfo  `json:"tracking_info"`
-}
-
-type ShipmentLabel struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-}
-
-type TrackingInfo struct {
-	CarrierName      string `json:"carrier_name,omitempty"`
-	TrackingNumber   string `json:"tracking_number,omitempty"`
-	CarrierNameOther string `json:"carrier_name_other,omitempty"`
-	TrackingUrl      string `json:"tracking_url,omitempty"`
-}
-
-type ReturnShippingAddress struct {
-	AddressLine1 string `json:"address_line_1,omitempty"`
-	AddressLine2 string `json:"address_line_2,omitempty"`
-	CountryCode  string `json:"country_code,omitempty"`
-	AdminArea1   string `json:"admin_area_1,omitempty"`
-	AdminArea2   string `json:"admin_area_2,omitempty"`
-	PostalCode   string `json:"postal_code,omitempty"`
-}
-
-type DisputeMakeOfferParams struct {
-	Note                  string                 `json:"note,omitempty"`
-	InvoiceId             string                 `json:"invoice_id,omitempty"`
-	OfferAmount           *Money                 `json:"offer_amount,omitempty"`
-	ReturnShippingAddress *ReturnShippingAddress `json:"return_shipping_address,omitempty"`
-	OfferType             MakeOfferType          `json:"offer_type,omitempty"`
-}
-
-type DisputeAcknowledgeReturnItemParams struct {
-	Note      string             `json:"note,omitempty"`
-	Evidences []*DisputeEvidence `json:"evidences,omitempty"`
-}
-
-type DisputeEvidence struct {
-	EvidenceType EvidenceType         `json:"evidence_type,omitempty"`
-	Documents    []*Document          `json:"documents,omitempty"`
-	Notes        string               `json:"notes,omitempty"`
-	ItemId       string               `json:"item_id,omitempty"`
-	EvidenceInfo *DisputeEvidenceInfo `json:"evidence_info,omitempty"`
-}
-
-type DisputeEvidenceInfo struct {
-	TrackingInfo []*TrackingInfo `json:"tracking_info,omitempty"`
-	RefundIds    []string        `json:"refund_ids,omitempty"`
-}
-
-type DisputeProvideEvidenceParams struct {
-	Evidences             *DisputeEvidence       `json:"evidences,omitempty"`
-	ReturnShippingAddress *ReturnShippingAddress `json:"return_shipping_address,omitempty"`
-}
-
-type DisputeAppealParams struct {
-	Evidences             *DisputeEvidence       `json:"evidences,omitempty"`
-	ReturnShippingAddress *ReturnShippingAddress `json:"return_shipping_address,omitempty"`
-}
-
 // ListDisputes - Lists disputes with a summary set of details.
 // Endpoint: GET /v1/customer/disputes
 // https://developer.paypal.com/docs/api/customer-disputes/v1/#disputes_list
 func (c *Client) ListDisputes(ctx context.Context, req *ListDisputesRequest) (*ListDisputesResponse, error) {
 	response := &ListDisputesResponse{}
 
-	r, err := c.NewRequest(ctx, "GET", fmt.Sprintf("%s%s", c.APIBase, "/v1/customer/disputes"), nil)
+	r, err := c.NewRequest(ctx, "GET", fmt.Sprintf("%s/v1/customer/disputes", c.APIBase), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +25,7 @@ func (c *Client) ListDisputes(ctx context.Context, req *ListDisputesRequest) (*L
 		q.Add("start_time", req.StartTime.Format(time.RFC3339))
 	}
 	if req.DisputedTransactionId != nil {
-		q.Add("disputed_transactioniId", *req.DisputedTransactionId)
+		q.Add("disputed_transaction_id", *req.DisputedTransactionId)
 	}
 	if req.PageSize != nil {
 		q.Add("page_size", strconv.Itoa(*req.PageSize))
@@ -268,7 +61,9 @@ func (c *Client) GetDisputeDetail(ctx context.Context, DisputeID string) (*GetDi
 	if err != nil {
 		return response, err
 	}
-	err = c.SendWithAuth(req, response)
+	if err = c.SendWithAuth(req, response); err != nil {
+		return nil, err
+	}
 	return response, err
 }
 
@@ -276,7 +71,7 @@ func (c *Client) GetDisputeDetail(ctx context.Context, DisputeID string) (*GetDi
 // Endpoint: PATCH /v1/customer/disputes/{id}
 // https://developer.paypal.com/docs/api/customer-disputes/v1/#disputes_patch
 func (c *Client) UpdateDispute(ctx context.Context, disputeId string, params *UpdateDisputeParams) error {
-	req, err := c.NewRequest(ctx, http.MethodPatch, fmt.Sprintf("%s%s%s", c.APIBase, "/v1/customer/disputes/", disputeId), params)
+	req, err := c.NewRequest(ctx, http.MethodPatch, fmt.Sprintf("%s/v1/customer/disputes/%s", c.APIBase, disputeId), params)
 	if err != nil {
 		return err
 	}
@@ -288,7 +83,7 @@ func (c *Client) UpdateDispute(ctx context.Context, disputeId string, params *Up
 // Endpoint: POST /v1/customer/disputes/{id}/provide-evidence
 // https://developer.paypal.com/docs/api/customer-disputes/v1/#disputes_provide-evidence
 func (c *Client) DisputeProvideEvidence(ctx context.Context, disputeId string, params *DisputeProvideEvidenceParams) error {
-	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s%s%s/provide-evidence", c.APIBase, "/v1/customer/disputes/", disputeId), params)
+	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s/v1/customer/disputes/%s/provide-evidence", c.APIBase, disputeId), params)
 	if err != nil {
 		return err
 	}
@@ -300,7 +95,7 @@ func (c *Client) DisputeProvideEvidence(ctx context.Context, disputeId string, p
 // Endpoint: POST /v1/customer/disputes/{id}/appeal
 // https://developer.paypal.com/docs/api/customer-disputes/v1/#disputes_appeal
 func (c *Client) DisputeAppeal(ctx context.Context, disputeId string, params *DisputeAppealParams) error {
-	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s%s%s/appeal", c.APIBase, "/v1/customer/disputes/", disputeId), params)
+	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s/v1/customer/disputes/%s/appeal", c.APIBase, disputeId), params)
 	if err != nil {
 		return err
 	}
@@ -312,7 +107,7 @@ func (c *Client) DisputeAppeal(ctx context.Context, disputeId string, params *Di
 // Endpoint: POST /v1/customer/disputes/{id}/accept-claim
 // https://developer.paypal.com/docs/api/customer-disputes/v1/#disputes_accept-claim
 func (c *Client) DisputeAcceptClaim(ctx context.Context, disputeId string, params *DisputeAcceptClaimParams) error {
-	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s%s%s/accept-claim", c.APIBase, "/v1/customer/disputes/", disputeId), params)
+	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s/v1/customer/disputes/%s/accept-claim", c.APIBase, disputeId), params)
 	if err != nil {
 		return err
 	}
@@ -324,7 +119,7 @@ func (c *Client) DisputeAcceptClaim(ctx context.Context, disputeId string, param
 // Endpoint: POST /v1/customer/disputes/{id}/adjudicate
 // https://developer.paypal.com/docs/api/customer-disputes/v1/#disputes_adjudicate
 func (c *Client) SettleDispute(ctx context.Context, disputeId string, adjudicateOutcome AdjudicationOutcome) error {
-	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s%s%s/adjudicate", c.APIBase, "/v1/customer/disputes/", disputeId), map[string]string{"adjudication_outcome": string(adjudicateOutcome)})
+	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s/v1/customer/disputes/%s/adjudicate", c.APIBase, disputeId), map[string]string{"adjudication_outcome": string(adjudicateOutcome)})
 	if err != nil {
 		return err
 	}
@@ -337,7 +132,7 @@ func (c *Client) SettleDispute(ctx context.Context, disputeId string, adjudicate
 // https://developer.paypal.com/docs/api/customer-disputes/v1/#disputes_require-evidence
 // Important: This method is for sandbox use only.
 func (c *Client) DisputeUpdateStatus(ctx context.Context, disputeId string, adjudicateOutcome AdjudicationOutcome) error {
-	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s%s%s/require-evidence", c.APIBase, "/v1/customer/disputes/", disputeId), map[string]string{"action": string(adjudicateOutcome)})
+	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s/v1/customer/disputes/%s/require-evidence", c.APIBase, disputeId), map[string]string{"action": string(adjudicateOutcome)})
 	if err != nil {
 		return err
 	}
@@ -349,7 +144,7 @@ func (c *Client) DisputeUpdateStatus(ctx context.Context, disputeId string, adju
 // Endpoint: POST /v1/customer/disputes/{id}/escalate
 // https://developer.paypal.com/docs/api/customer-disputes/v1/#disputes_escalate
 func (c *Client) DisputeEscalateToClaim(ctx context.Context, disputeId string, note string) error {
-	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s%s%s/escalate", c.APIBase, "/v1/customer/disputes/", disputeId), map[string]string{"note": note})
+	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s/v1/customer/disputes/%s/escalate", c.APIBase, disputeId), map[string]string{"note": note})
 	if err != nil {
 		return err
 	}
@@ -361,7 +156,7 @@ func (c *Client) DisputeEscalateToClaim(ctx context.Context, disputeId string, n
 // Endpoint: POST /v1/customer/disputes/{id}/send-message
 // https://developer.paypal.com/docs/api/customer-disputes/v1/#disputes_send-message
 func (c *Client) DisputeSendMessageToOtherParty(ctx context.Context, disputeId string, message string) error {
-	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s%s%s/send-message", c.APIBase, "/v1/customer/disputes/", disputeId), map[string]string{"message": message})
+	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s/v1/customer/disputes/%s/send-message", c.APIBase, disputeId), map[string]string{"message": message})
 	if err != nil {
 		return err
 	}
@@ -373,7 +168,7 @@ func (c *Client) DisputeSendMessageToOtherParty(ctx context.Context, disputeId s
 // Endpoint: POST /v1/customer/disputes/{id}/make-offer
 // https://developer.paypal.com/docs/api/customer-disputes/v1/#disputes_make-offer
 func (c *Client) DisputeMakeOffer(ctx context.Context, disputeId string, params *DisputeMakeOfferParams) error {
-	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s%s%s/make-offer", c.APIBase, "/v1/customer/disputes/", disputeId), params)
+	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s/v1/customer/disputes/%s/make-offer", c.APIBase, disputeId), params)
 	if err != nil {
 		return err
 	}
@@ -385,7 +180,7 @@ func (c *Client) DisputeMakeOffer(ctx context.Context, disputeId string, params 
 // Endpoint: POST /v1/customer/disputes/{id}/accept-offer
 // https://developer.paypal.com/docs/api/customer-disputes/v1/#disputes_accept-offer
 func (c *Client) DisputeAcceptOffer(ctx context.Context, disputeId string, note string) error {
-	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s%s%s/accept-offer", c.APIBase, "/v1/customer/disputes/", disputeId), map[string]string{"note": note})
+	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s/v1/customer/disputes/%s/accept-offer", c.APIBase, disputeId), map[string]string{"note": note})
 	if err != nil {
 		return err
 	}
@@ -397,7 +192,7 @@ func (c *Client) DisputeAcceptOffer(ctx context.Context, disputeId string, note 
 // Endpoint: POST /v1/customer/disputes/{id}/deny-offer
 // https://developer.paypal.com/docs/api/customer-disputes/v1/#disputes_deny-offer
 func (c *Client) DisputeDenyOffer(ctx context.Context, disputeId string, note string) error {
-	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s%s%s/deny-offer", c.APIBase, "/v1/customer/disputes/", disputeId), map[string]string{"note": note})
+	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s/v1/customer/disputes/%s/deny-offer", c.APIBase, disputeId), map[string]string{"note": note})
 	if err != nil {
 		return err
 	}
@@ -409,7 +204,7 @@ func (c *Client) DisputeDenyOffer(ctx context.Context, disputeId string, note st
 // Endpoint: POST /v1/customer/disputes/{id}/acknowledge-return-item
 // https://developer.paypal.com/docs/api/customer-disputes/v1/#disputes_acknowledge-return-item
 func (c *Client) DisputeAcknowledgeReturnItem(ctx context.Context, disputeId string, params *DisputeAcknowledgeReturnItemParams) error {
-	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s%s%s/acknowledge-return-item", c.APIBase, "/v1/customer/disputes/", disputeId), params)
+	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s/v1/customer/disputes/%s/acknowledge-return-item", c.APIBase, disputeId), params)
 	if err != nil {
 		return err
 	}
@@ -421,7 +216,7 @@ func (c *Client) DisputeAcknowledgeReturnItem(ctx context.Context, disputeId str
 // Endpoint: POST /v1/customer/disputes/{id}/provide-supporting-info
 // https://developer.paypal.com/docs/api/customer-disputes/v1/#disputes_provide-supporting-info
 func (c *Client) DisputeProvideSupportingInfo(ctx context.Context, disputeId string, notes string) error {
-	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s%s%s/provide-supporting-info", c.APIBase, "/v1/customer/disputes/", disputeId), map[string]string{"notes": notes})
+	req, err := c.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s/v1/customer/disputes/%s/provide-supporting-info", c.APIBase, disputeId), map[string]string{"notes": notes})
 	if err != nil {
 		return err
 	}

--- a/dispute.go
+++ b/dispute.go
@@ -75,8 +75,11 @@ func (c *Client) UpdateDispute(ctx context.Context, disputeId string, params *Up
 	if err != nil {
 		return err
 	}
-	err = c.SendWithAuth(req, nil)
-	return err
+	if err = c.SendWithAuth(req, nil); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Provides evidence for a dispute, by ID
@@ -87,8 +90,11 @@ func (c *Client) DisputeProvideEvidence(ctx context.Context, disputeId string, p
 	if err != nil {
 		return err
 	}
-	err = c.SendWithAuth(req, nil)
-	return err
+	if err = c.SendWithAuth(req, nil); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Appeals a dispute, by ID
@@ -99,8 +105,11 @@ func (c *Client) DisputeAppeal(ctx context.Context, disputeId string, params *Di
 	if err != nil {
 		return err
 	}
-	err = c.SendWithAuth(req, nil)
-	return err
+	if err = c.SendWithAuth(req, nil); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Accepts liability for a claim, by ID
@@ -111,8 +120,11 @@ func (c *Client) DisputeAcceptClaim(ctx context.Context, disputeId string, param
 	if err != nil {
 		return err
 	}
-	err = c.SendWithAuth(req, nil)
-	return err
+	if err = c.SendWithAuth(req, nil); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Settles a dispute in either the customer's or merchant's favor.
@@ -123,8 +135,11 @@ func (c *Client) SettleDispute(ctx context.Context, disputeId string, adjudicate
 	if err != nil {
 		return err
 	}
-	err = c.SendWithAuth(req, nil)
-	return err
+	if err = c.SendWithAuth(req, nil); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Updates the status of a dispute, by ID
@@ -136,8 +151,11 @@ func (c *Client) DisputeUpdateStatus(ctx context.Context, disputeId string, adju
 	if err != nil {
 		return err
 	}
-	err = c.SendWithAuth(req, nil)
-	return err
+	if err = c.SendWithAuth(req, nil); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Escalates the dispute, by ID
@@ -148,8 +166,11 @@ func (c *Client) DisputeEscalateToClaim(ctx context.Context, disputeId string, n
 	if err != nil {
 		return err
 	}
-	err = c.SendWithAuth(req, nil)
-	return err
+	if err = c.SendWithAuth(req, nil); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Sends a message about a dispute, by ID, to the other party in the dispute.
@@ -160,8 +181,11 @@ func (c *Client) DisputeSendMessageToOtherParty(ctx context.Context, disputeId s
 	if err != nil {
 		return err
 	}
-	err = c.SendWithAuth(req, nil)
-	return err
+	if err = c.SendWithAuth(req, nil); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Makes an offer to the other party to resolve a dispute, by ID
@@ -172,8 +196,11 @@ func (c *Client) DisputeMakeOffer(ctx context.Context, disputeId string, params 
 	if err != nil {
 		return err
 	}
-	err = c.SendWithAuth(req, nil)
-	return err
+	if err = c.SendWithAuth(req, nil); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // The customer accepts the offer from merchant to resolve a dispute, by ID
@@ -184,8 +211,11 @@ func (c *Client) DisputeAcceptOffer(ctx context.Context, disputeId string, note 
 	if err != nil {
 		return err
 	}
-	err = c.SendWithAuth(req, nil)
-	return err
+	if err = c.SendWithAuth(req, nil); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Denies an offer that the merchant proposes for a dispute, by ID.
@@ -196,8 +226,11 @@ func (c *Client) DisputeDenyOffer(ctx context.Context, disputeId string, note st
 	if err != nil {
 		return err
 	}
-	err = c.SendWithAuth(req, nil)
-	return err
+	if err = c.SendWithAuth(req, nil); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Acknowledges that the customer returned an item for a dispute, by ID.
@@ -208,8 +241,11 @@ func (c *Client) DisputeAcknowledgeReturnItem(ctx context.Context, disputeId str
 	if err != nil {
 		return err
 	}
-	err = c.SendWithAuth(req, nil)
-	return err
+	if err = c.SendWithAuth(req, nil); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Provides supporting information for a dispute, by ID.
@@ -220,6 +256,9 @@ func (c *Client) DisputeProvideSupportingInfo(ctx context.Context, disputeId str
 	if err != nil {
 		return err
 	}
-	err = c.SendWithAuth(req, nil)
-	return err
+	if err = c.SendWithAuth(req, nil); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/dispute_types.go
+++ b/dispute_types.go
@@ -1,0 +1,158 @@
+package paypal
+
+// https://developer.paypal.com/docs/api/customer-disputes/v1/#definition-dispute_info
+type DisputeState string
+
+const (
+	DisputeStateOpenInquiries            DisputeState = "OPEN_INQUIRIES"              //The dispute is open.
+	DisputeStateRequiredAction           DisputeState = "REQUIRED_ACTION"             //The dispute is waiting for a response.
+	DisputeStateRequiredOtherPartyAction DisputeState = "REQUIRED_OTHER_PARTY_ACTION" //The dispute is waiting for a response from other party.
+	DisputeStateUnderPaypalReview        DisputeState = "UNDER_PAYPAL_REVIEW"         //The dispute is under review with PayPal.
+	DisputeStateAppealable               DisputeState = "APPEALABLE"                  //The dispute can be appealed.
+	DisputeStateResolved                 DisputeState = "RESOLVED"                    //The dispute is resolved.
+)
+
+type AcceptClaimReason string
+
+const (
+	AcceptClaimReasonDidNotShipItem   AcceptClaimReason = "DID_NOT_SHIP_ITEM"  //Merchant is accepting customer's claim as they could not ship the item back to the customer
+	AcceptClaimReasonTooTimeConsuming AcceptClaimReason = "TOO_TIME_CONSUMING" //Merchant is accepting customer's claim as it is taking too long for merchant to fulfil the order
+	AcceptClaimReasonLostInMail       AcceptClaimReason = "LOST_IN_MAIL"       //Merchant is accepting customer's claim as the item is lost in mail or transit
+	AcceptClaimReasonNotAbleToWin     AcceptClaimReason = "NOT_ABLE_TO_WIN"    //Merchant is accepting customer's claim as the merchant is not able to find sufficient evidence to win this dispute
+	AcceptClaimReasonCompanyPolicy    AcceptClaimReason = "COMPANY_POLICY"     //Merchant is accepting customer’s claims to follow their internal company policy
+	AcceptClaimReasonReasonNotSet     AcceptClaimReason = "REASON_NOT_SET"     //This is the default value merchant can use if none of the above reasons apply
+)
+
+type AcceptClaimType string
+
+const (
+	AcceptClaimTypeRefund                        AcceptClaimType = "REFUND"                            //	The merchant must refund the customer without any item replacement or return. This type is applicable when a merchant is willing to refund the entire dispute amount without any further action from customer. Omit the refund_amount and return_shipping_address parameters from the accept claim call.
+	AcceptClaimTypeRefundWithReturn              AcceptClaimType = "REFUND_WITH_RETURN"                //	The customer must return the item to the merchant and then merchant will refund the money. This type is applicable when a merchant is willing to refund the dispute amount and requires the customer to return the item. Include the return_shipping_address parameter in but omit the refund_amount parameter from the accept claim call.
+	AcceptClaimTypePartialRefund                 AcceptClaimType = "PARTIAL_REFUND"                    //	The merchant proposes a partial refund for the dispute.This type is applicable when a merchant is willing to refund an amount lesser than dispute amount. Include the refund_amount parameter.
+	AcceptClaimTypeRefundWithReturnShipmentLabel AcceptClaimType = "REFUND_WITH_RETURN_SHIPMENT_LABEL" //	The customer must return the item to the merchant and then merchant will refund the money. This type is applicable when a merchant is willing to refund the dispute amount and requires the customer to return the item using the shipment label provided by the merchant. Include the return_shipment_info and return_shipping_address parameter in but omit the refund_amount parameter from the accept claim call.
+)
+
+type AdjudicationOutcome string
+
+const (
+	AdjudicationOutcomeBuyerFavor  AdjudicationOutcome = "BUYER_FAVOR"  //	Resolves the case in the customer's favor. Outcome is set to RESOLVED_BUYER_FAVOR.
+	AdjudicationOutcomeSellerFavor AdjudicationOutcome = "SELLER_FAVOR" //	Resolves the case in the merchant's favor. Outcome is set to RESOLVED_SELLER_FAVOR.
+)
+
+type DisputeStatusAction string
+
+const (
+	DisputeStatusBuyerEvidence  DisputeStatusAction = "BUYER_EVIDENCE"  //	Changes the status of the dispute to WAITING_FOR_BUYER_RESPONSE.
+	DisputeStatusSellerEvidence DisputeStatusAction = "SELLER_EVIDENCE" //	Changes the status of the dispute to WAITING_FOR_SELLER_RESPONSE.
+)
+
+type DisputeStatus string
+
+const (
+	DisputeStatusOpen                     DisputeStatus = "OPEN"                        //	The dispute is open.
+	DisputeStatusWaitingForBuyerResponse  DisputeStatus = "WAITING_FOR_BUYER_RESPONSE"  //	The dispute is waiting for a response from the customer.
+	DisputeStatusWaitingForSellerResponse DisputeStatus = "WAITING_FOR_SELLER_RESPONSE" //	The dispute is waiting for a response from the merchant.
+	DisputeStatusUnderReview              DisputeStatus = "UNDER_REVIEW"                //	The dispute is under review with PayPal.
+	DisputeStatusResolved                 DisputeStatus = "RESOLVED"                    //	The dispute is resolved.
+	DisputeStatusOther                    DisputeStatus = "OTHER"                       //	The default status if the dispute does not have one of the other statuses.
+)
+
+type MakeOfferType string
+
+const (
+	MakeOfferTypeRefund                   MakeOfferType = "REFUND"                     //	The merchant must refund the customer without any item replacement or return. This offer type is valid in the inquiry phase and occurs when a merchant is willing to refund a specific amount. Buyer acceptance is needed for partial refund offers and dispute is auto closed for full refunds. Include the offer_amount but omit the return_shipping_address parameters from the make offer request.
+	MakeOfferTypeRefundWithReturn         MakeOfferType = "REFUND_WITH_RETURN"         //	The customer must return the item to the merchant and then merchant will refund the money. This offer type is valid in the inquiry phase and occurs when a merchant is willing to refund a specific amount and requires the customer to return the item. Include the return_shipping_address parameter and the offer_amount parameter in the make offer request.
+	MakeOfferTypeRefundWithReplacement    MakeOfferType = "REFUND_WITH_REPLACEMENT"    //	The merchant must do a refund and then send a replacement item to the customer. This offer type is valid in the inquiry phase when a merchant is willing to refund a specific amount and send the replacement item. Include the offer_amount parameter in the make offer request.
+	MakeOfferTypeReplacementWithoutRefund MakeOfferType = "REPLACEMENT_WITHOUT_REFUND" //	The merchant must send a replacement item to the customer with no additional refunds. This offer type is valid in the inquiry phase when a merchant is willing to replace the item without any refund. Omit the offer_amount parameter from the make offer request.
+)
+
+type AcknowledgementType string
+
+const (
+	AcknowledgementTypeItemReceived            AcknowledgementType = "ITEM_RECEIVED"              //	The merchant must refund the customer without any item replacement or return. This offer type is valid in the inquiry phase and occurs when a merchant is willing to refund a specific amount. Buyer acceptance is needed for partial refund offers and dispute is auto closed for full refunds. Include the offer_amount but omit the return_shipping_address parameters from the make offer request.
+	AcknowledgementTypeItemNotReceived         AcknowledgementType = "ITEM_NOT_RECEIVED"          //	The merchant has not received the item.
+	AcknowledgementTypeDamaged                 AcknowledgementType = "DAMAGED"                    //	The items returned by the customer were damaged.
+	AcknowledgementTypeEmptyPackageOrDifferent AcknowledgementType = "EMPTY_PACKAGE_OR_DIFFERENT" //	The package was empty or the goods were different from what was expected.
+	AcknowledgementTypeMissingItems            AcknowledgementType = "MISSING_ITEMS"              //	The package did not have all the items that were expected.
+)
+
+type EvidenceType string
+
+const (
+	EvidenceTypeProofOfDamage                                   EvidenceType = "PROOF_OF_DAMAGE"                                       //	Documentation supporting the claim that the item is damaged.
+	EvidenceTypeThirdpartyProofForDamageOrSignificantDifference EvidenceType = "THIRDPARTY_PROOF_FOR_DAMAGE_OR_SIGNIFICANT_DIFFERENCE" //	Proof should be provided by an unbiased third-party, such as a dealer, appraiser or another individual or organisation that's qualified in the area of the item in question (other than yourself), and detail the extent of the damage or clearly explain how the item received significantly differs from the item advertised.
+	EvidenceTypeDelcaration                                     EvidenceType = "DECLARATION"                                           //	Signed declaration about the information provided.
+	EvidenceTypeProofOfMissingItems                             EvidenceType = "PROOF_OF_MISSING_ITEMS"                                //	Image of open box with returned items and shipping label clearly visible.
+	EvidenceTypeProofOfEmptyPackageOrDifferentItem              EvidenceType = "PROOF_OF_EMPTY_PACKAGE_OR_DIFFERENT_ITEM"              //	Image of empty box or returned items that are different from what were expected and shipping label clearly visible.
+	EvidenceTypeProofOfItemNotReceived                          EvidenceType = "PROOF_OF_ITEM_NOT_RECEIVED"                            //	Any proof about the non receipt of the item, such as screenshot of tracking info.
+	EvidenceTypeProofOfFulfillment                              EvidenceType = "PROOF_OF_FULFILLMENT"                                  //	Proof of fulfillment should be a copy of the actual shipping label on the package that shows the destination address and the shipping company's stamp to verify the shipment date.
+	EvidenceTypeProofOfRefund                                   EvidenceType = "PROOF_OF_REFUND"                                       //	Proof of refund issued to the buyer
+	EvidenceTypeProofOfDeliverySignature                        EvidenceType = "PROOF_OF_DELIVERY_SIGNATURE"                           //	Proof of delivery signature.
+	EvidenceTypeProofOfReceiptCopy                              EvidenceType = "PROOF_OF_RECEIPT_COPY"                                 //	Copy of original receipt or invoice.
+	EvidenceTypeReturnPolicy                                    EvidenceType = "RETURN_POLICY"                                         //	Copy of terms and conditions,contract or store return policy
+	EvidenceTypeBillingAgreement                                EvidenceType = "BILLING_AGREEMENT"                                     //	Copy of billing agreement.
+	EvidenceTypeProofOfReshipment                               EvidenceType = "PROOF_OF_RESHIPMENT"                                   //	Proof of reshipment should be a copy of the actual shipping label on the package that shows the destination address and the shipping company's stamp to verify the reshipment date.
+	EvidenceTypeItemDescription                                 EvidenceType = "ITEM_DESCRIPTION"                                      //	A copy of the original description of the item or service
+	EvidenceTypePoliceReport                                    EvidenceType = "POLICE_REPORT"                                         //	Copy of the police report filed.
+	EvidenceTypeAffidavit                                       EvidenceType = "AFFIDAVIT"                                             //	More information has to be provided about the claim using the affidavit.
+	EvidenceTypePaidWithOtherMethod                             EvidenceType = "PAID_WITH_OTHER_METHOD"                                //	Document showing item/service was paid by another payment method.
+	EvidenceTypeCopyOfContract                                  EvidenceType = "COPY_OF_CONTRACT"                                      //	Copy of contract if applicable.
+	EvidenceTypeTerminalAtmReceipt                              EvidenceType = "TERMINAL_ATM_RECEIPT"                                  //	Copy of terminal/ATM receipt.
+	EvidenceTypePriceDifferenceReason                           EvidenceType = "PRICE_DIFFERENCE_REASON"                               //	Explanation of what the price difference is related to (increased tip amount, shipping charges, taxes, etc).
+	EvidenceTypeSourceConversionRate                            EvidenceType = "SOURCE_CONVERSION_RATE"                                //	Source of expected conversion rate or fee.
+	EvidenceTypeBankStatement                                   EvidenceType = "BANK_STATEMENT"                                        //	Bank/Credit statement showing withdrawal transaction.
+	EvidenceTypeCreditDueReason                                 EvidenceType = "CREDIT_DUE_REASON"                                     //	The credit due reason.
+	EvidenceTypeRequestCreditReceipt                            EvidenceType = "REQUEST_CREDIT_RECEIPT"                                //	The request credit receipt.
+	EvidenceTypeProofOfReturn                                   EvidenceType = "PROOF_OF_RETURN"                                       //	Proof of shipment or postage that shows you returned this item to your seller and should be a copy of the actual shipping label used.
+	EvidenceTypeCreate                                          EvidenceType = "CREATE"                                                //	Additional evidence information during case creation.
+	EvidenceTypeChangeReason                                    EvidenceType = "CHANGE_REASON"                                         //	The evidence related to the reason change.
+	EvidenceTypeProofOfRefundOutsidePaypa                       EvidenceType = "PROOF_OF_REFUND_OUTSIDE_PAYPA"                         //L	Document should show that the seller issued a refund outside Paypal.
+	EvidenceTypeReceiptOfMerchandise                            EvidenceType = "RECEIPT_OF_MERCHANDISE"                                //	Check with buyer if item Delivered (seller provided Proof of Shipping)
+	EvidenceTypeCustomsDocument                                 EvidenceType = "CUSTOMS_DOCUMENT"                                      //	Document confirming that the item has been confiscated.
+	EvidenceTypeCustomsFeeReceipt                               EvidenceType = "CUSTOMS_FEE_RECEIPT"                                   //	Custom fees receipt paid by the buyer
+	EvidenceTypeInformationOnResolution                         EvidenceType = "INFORMATION_ON_RESOLUTION"                             //	Any resolution reached with the seller should be communicated to PayPal.
+	EvidenceTypeAdditionalInformationOfItem                     EvidenceType = "ADDITIONAL_INFORMATION_OF_ITEM"                        //	Any additional information of the item purchased.
+	EvidenceTypeDetailsOfPurchase                               EvidenceType = "DETAILS_OF_PURCHASE"                                   //	Specific details of a purchase made under a particular transaction has to be given.
+	EvidenceTypeProofOfSignificantDifference                    EvidenceType = "PROOF_OF_SIGNIFICANT_DIFFERENCE"                       //	More information required on how the item was damaged or was significantly different from the item advertised.
+	EvidenceTypeProofOfSoftwareOrServiceNotAsDescribed          EvidenceType = "PROOF_OF_SOFTWARE_OR_SERVICE_NOT_AS_DESCRIBED"         //	Any screenshot or download/usage log showing that the software or service was unavailable or non-functional.
+	EvidenceTypeProofOfConfiscation                             EvidenceType = "PROOF_OF_CONFISCATION	Documentation"                   // from a third party or organization that evaluated this item that confirms they confiscated it.
+	EvidenceTypeCopyOfLawEnforcementAgencyReport                EvidenceType = "COPY_OF_LAW_ENFORCEMENT_AGENCY_REPORT"                 //	Report filed with a law enforcement agency or government organization. Examples of such agencies are - Internet Crime Complaint Center (www.ic3.gov), state Consumer Protection office, state police or a Federal law enforcement agency such as the FBI or Postal Inspection Service.
+	EvidenceTypeAdditionalProofOfShipment                       EvidenceType = "ADDITIONAL_PROOF_OF_SHIPMENT"                          //	Additional proof of shipment such as a packing list, detailed invoice, or shipping manifest to confirm that all items have been shipped. Include carrier name and tracking number if available.
+	EvidenceTypeProofOfDenialByCarrier                          EvidenceType = "PROOF_OF_DENIAL_BY_CARRIER"                            //	Documentation from the carrier should confirm the reason why they refuse to ship the item in question and the extent of the original damage.
+	EvidenceTypeValidSupportingDocument                         EvidenceType = "VALID_SUPPORTING_DOCUMENT"                             //	The document you have provided doesn't support your claim that the item is Significantly Not as Described. Please provide a document to clearly show how the item received significantly differs from the item advertised.
+	EvidenceTypeLegibleSupportingDocument                       EvidenceType = "LEGIBLE_SUPPORTING_DOCUMENT"                           //	The document you have provided is illegible, unclear, or too dark to read. Please provide a document that is legible and clear to read.
+	EvidenceTypeReturnTrackingInformation                       EvidenceType = "RETURN_TRACKING_INFORMATION"                           //	Online tracking information for remaining items that have to be shipped to the seller.
+	EvidenceTypeDeliveryReceipt                                 EvidenceType = "DELIVERY_RECEIPT"                                      //	Confirmation that the item has been received.
+	EvidenceTypeProofOfInstoreReceipt                           EvidenceType = "PROOF_OF_INSTORE_RECEIPT"                              //	In-store receipt or online verification should clearly show that the buyer picked up the item.
+	EvidenceTypeAdditionalTrackingInformation                   EvidenceType = "ADDITIONAL_TRACKING_INFORMATION"                       //	Tracking information should include the carrier name, online tracking number and the website where the shipment can be tracked.
+	EvidenceTypeProofOfShipmentPostage                          EvidenceType = "PROOF_OF_SHIPMENT_POSTAGE"                             //	Proof of shipment or postage should be a copy of the actual shipping label on the package that shows the destination address and the carrier's stamp to verify the shipment date.
+	EvidenceTypeOnlineTrackingInformation                       EvidenceType = "ONLINE_TRACKING_INFORMATION"                           //	Online tracking information to confirm delivery of item.
+	EvidenceTypeProofOfInstoreRefund                            EvidenceType = "PROOF_OF_INSTORE_REFUND"                               //	Proof should be an in-store refund receipt or company documentation that clearly shows a completed refund for the transaction.
+	EvidenceTypeProofForSoftwareOrServiceDelivered              EvidenceType = "PROOF_FOR_SOFTWARE_OR_SERVICE_DELIVERED"               //	Proof should be compelling evidence to prove that the item or service was as described and was delivered to the buyer. Include information such as transaction ID, invoice ID, name or email to associate the evidence with the buyer along with date and time of the delivery.
+	EvidenceTypeReturnAddressForShipping                        EvidenceType = "RETURN_ADDRESS_FOR_SHIPPING"                           //	Return address is required for the buyer to ship the merchandise back to the seller.
+	EvidenceTypeCopyOfTheEparcelManifest                        EvidenceType = "COPY_OF_THE_EPARCEL_MANIFEST"                          //	To validate a claim, a copy of the eparcel manifest showing the buyer's address from Australia Post is required.
+	EvidenceTypeCopyOfShippingManifest                          EvidenceType = "COPY_OF_SHIPPING_MANIFEST"                             //	The shipping manifest must show the buyer's address and can be obtained from the carrier.
+	EvidenceTypeAppealAffidavit                                 EvidenceType = "APPEAL_AFFIDAVIT"                                      //	Appeal affidavit is needed to make an appeal for any case outcome.
+	EvidenceTypeReceiptOfReplacement                            EvidenceType = "RECEIPT_OF_REPLACEMENT"                                //	Check with buyer if the replacement of the item sent by the seller was received
+	EvidenceTypeCopyOfDriversLicense                            EvidenceType = "COPY_OF_DRIVERS_LICENSE"                               //	Need Copy of Drivers license.
+	EvidenceTypeAccountChangeInformation                        EvidenceType = "ACCOUNT_CHANGE_INFORMATION"                            //	Additional Details about how account was accessed/what was changed.
+	EvidenceTypeDeliveryAddress                                 EvidenceType = "DELIVERY_ADDRESS"                                      //	Address where item was supposed to be delivered.
+	EvidenceTypeConfirmationOfResolution                        EvidenceType = "CONFIRMATION_OF_RESOLUTION"                            //	Confirmation that item was received and issue resolved.
+	EvidenceTypeMerchantResponse                                EvidenceType = "MERCHANT_RESPONSE"                                     //	Copy of merchant's response when the resolution was attempted.
+	EvidenceTypePermissionDescription                           EvidenceType = "PERMISSION_DESCRIPTION"                                //	A Detailed description about the account or card level permission given to another person.
+	EvidenceTypeStatusOfMerchandise                             EvidenceType = "STATUS_OF_MERCHANDISE"                                 //	Details of the merchandise's current location.
+	EvidenceTypeLostCardDetails                                 EvidenceType = "LOST_CARD_DETAILS"                                     //	Details of where and when the card was lost/stolen?.
+	EvidenceTypeLastValidTransactionDetails                     EvidenceType = "LAST_VALID_TRANSACTION_DETAILS"                        //	Details of the last valid transaction made on the card.
+	EvidenceTypeAdditionalProofOfReturn                         EvidenceType = "ADDITIONAL_PROOF_OF_RETURN"                            //	Document to confirm that the item to be returned to the seller has been shipped.
+	EvidenceTypeOrderDetails                                    EvidenceType = "ORDER_DETAILS"                                         //	Order details or photos of the item/service/booking/digital download available on the website.
+	EvidenceTypeListingUrl                                      EvidenceType = "LISTING_URL"                                           //	The website URLs of the item/service/booking/digital download.
+	EvidenceTypeShippingInsurance                               EvidenceType = "SHIPPING_INSURANCE"                                    //	Insurance information of the shipped item.
+	EvidenceTypeBuyerResponse                                   EvidenceType = "BUYER_RESPONSE"                                        //	Copy of the buyer response or any other document showing buyer's understanding of the item/service/booking/digital download purchased.
+	EvidenceTypePhotosOfShippedItem                             EvidenceType = "PHOTOS_OF_SHIPPED_ITEM"                                //	Photos of the item that were shipped to the buyer.
+	EvidenceTypeOther                                           EvidenceType = "OTHER"                                                 //	Other.
+	EvidenceTypeCancellationDetails                             EvidenceType = "CANCELLATION_DETAILS"                                  //	Cancellation details information, for example- cancellation date, cancellation number.
+	EvidenceTypeMerchantContactDetails                          EvidenceType = "MERCHANT_CONTACT_DETAILS"                              //	Merchant contacted details information, for example- merchant contacted time, mode of contacting.
+	EvidenceTypeItemDetails                                     EvidenceType = "ITEM_DETAILS"                                          //	Item related details information, for example- expected delivery date.
+	EvidenceTypeCorrectRecipientInformation                     EvidenceType = "CORRECT_RECIPIENT_INFORMATION"                         //	Proof of the correct recipient name, email or phone.
+	EvidenceTypeExplanationOfFundsNotDelivered                  EvidenceType = "EXPLANATION_OF_FUNDS_NOT_DELIVERED"                    //	Details on why the funds were not delivered to the correct recipient.
+)

--- a/dispute_types.go
+++ b/dispute_types.go
@@ -1,158 +1,367 @@
 package paypal
 
+import "time"
+
+type ListDisputesRequest struct {
+	StartTime             *time.Time
+	DisputedTransactionId *string
+	PageSize              *int
+	NextPageToken         *string
+	DisputeState          *string
+	UpdateTimeBefore      *time.Time
+	UpdateTimeAfter       *time.Time
+}
+
+type ListDisputesResponse struct {
+	Items []*DisputeItem `json:"items,omitempty"`
+	Links []Link         `json:"links,omitempty"`
+}
+
+type DisputeItem struct {
+	DisputeID             string                     `json:"dispute_id,omitempty"`
+	CreateTime            time.Time                  `json:"create_time,omitempty"`
+	UpdateTime            time.Time                  `json:"update_time,omitempty"`
+	DisputedTransactions  []*DisputedTransactionItem `json:"disputed_transactions,omitempty"`
+	Reason                string                     `json:"reason,omitempty"`
+	Status                string                     `json:"status,omitempty"`
+	DisputeState          DisputeState               `json:"dispute_state,omitempty"`
+	DisputeAmount         *Money                     `json:"dispute_amount,omitempty"`
+	Outcome               string                     `json:"outcome,omitempty"`
+	DisputeLifeCycleStage string                     `json:"dispute_life_cycle_stage,omitempty"`
+	DisputeChannel        string                     `json:"dispute_channel,omitempty"`
+	DisputeFlow           string                     `json:"dispute_flow,omitempty"`
+	Links                 []Link                     `json:"links,omitempty"`
+}
+
+type DisputedTransactionItem struct {
+	BuyerTransactionID string `json:"buyer_transaction_id,omitempty"`
+	Buyer              Buyer  `json:"buyer,omitempty"`
+	Seller             Seller `json:"seller,omitempty"`
+}
+
+type Buyer struct {
+	PayerID string `json:"payer_id,omitempty"`
+	Name    string `json:"name,omitempty"`
+}
+
+type Seller struct {
+	Email      string `json:"email,omitempty"`
+	MerchantID string `json:"merchant_id,omitempty"`
+	Name       string `json:"name,omitempty"`
+}
+
+type GetDisputeDetailResponse struct {
+	DisputeID             string                       `json:"dispute_id,omitempty"`
+	CreateTime            time.Time                    `json:"create_time,omitempty"`
+	UpdateTime            time.Time                    `json:"update_time,omitempty"`
+	DisputedTransactions  []*DisputedTransactionDetail `json:"disputed_transactions,omitempty"`
+	Reason                string                       `json:"reason,omitempty"`
+	Status                string                       `json:"status,omitempty"`
+	DisputeAmount         *Money                       `json:"dispute_amount,omitempty"`
+	DisputeOutcome        *DisputeOutcome              `json:"dispute_outcome,omitempty"`
+	DisputeLifeCycleStage string                       `json:"dispute_life_cycle_stage,omitempty"`
+	DisputeChannel        string                       `json:"dispute_channel,omitempty"`
+	Messages              []*Message                   `json:"messages,omitempty"`
+	Extensions            *Extensions                  `json:"extensions,omitempty"`
+	Offer                 *Offer                       `json:"offer,omitempty"`
+	Links                 []Link                       `json:"links,omitempty"`
+}
+
+type DisputeOutcome struct {
+	OutcomeCode    string `json:"outcome_code,omitempty"`
+	AmountRefunded *Money `json:"amount_refunded,omitempty"`
+}
+
+type DisputedTransactionDetail struct {
+	SellerTransactionID string    `json:"seller_transaction_id,omitempty"`
+	CreateTime          time.Time `json:"create_time,omitempty"`
+	TransactionStatus   string    `json:"transaction_status,omitempty"`
+	GrossAmount         *Money    `json:"gross_amount,omitempty"`
+	Buyer               Buyer     `json:"buyer,omitempty"`
+	Seller              Seller    `json:"seller,omitempty"`
+}
+
+type Extensions struct {
+	MerchandizeDisputeProperties MerchandizeDisputeProperties `json:"merchandize_dispute_properties,omitempty"`
+}
+
+type MerchandizeDisputeProperties struct {
+	IssueType      string          `json:"issue_type,omitempty"`
+	ServiceDetails *ServiceDetails `json:"service_details,omitempty"`
+}
+
+type ServiceDetails struct {
+	SubReasons  []string `json:"sub_reasons,omitempty"`
+	PurchaseURL string   `json:"purchase_url,omitempty"`
+}
+
+type Message struct {
+	PostedBy   string      `json:"posted_by,omitempty"`
+	TimePosted time.Time   `json:"time_posted,omitempty"`
+	Content    string      `json:"content,omitempty"`
+	Documents  []*Document `json:"documents,omitempty"`
+}
+
+type Document struct {
+	Name string `json:"name,omitempty"`
+	URL  string `json:"url,omitempty"`
+}
+
+type Offer struct {
+	BuyerRequestedAmount *Money     `json:"buyer_requested_amount,omitempty"`
+	OfferType            string     `json:"offer_type,omitempty"`
+	History              []*History `json:"history,omitempty"`
+}
+
+type History struct {
+	OfferTime             time.Time `json:"offer_time,omitempty"`
+	Actor                 string    `json:"actor,omitempty"`
+	EventType             string    `json:"event_type,omitempty"`
+	OfferType             string    `json:"offer_type,omitempty"`
+	OfferAmount           *Money    `json:"offer_amount,omitempty"`
+	Notes                 string    `json:"notes,omitempty"`
+	DisputeLifeCycleStage string    `json:"dispute_life_cycle_stage,omitempty"`
+}
+
+type UpdateDisputeValue struct {
+	ID         string    `json:"id,omitempty"`
+	Name       string    `json:"name,omitempty"`
+	CreateTime time.Time `json:"create_time,omitempty"`
+	Reason     string    `json:"reason,omitempty"`
+	Status     string    `json:"status,omitempty"`
+}
+
+type UpdateDisputeParams struct {
+	Op    string              `json:"op,omitempty"`
+	Path  string              `json:"path,omitempty"`
+	Value *UpdateDisputeValue `json:"value,omitempty"`
+}
+
+type DisputeAcceptClaimParams struct {
+	Note                  string                 `json:"note,omitempty"`
+	AcceptClaimReason     AcceptClaimReason      `json:"accept_claim_reason,omitempty"`
+	InvoiceId             string                 `json:"invoice_id,omitempty"`
+	RefundAmount          *Money                 `json:"refund_amount,omitempty"`
+	ReturnShippingAddress *ReturnShippingAddress `json:"return_shipping_address,omitempty"`
+	ReturnShipmentInfo    []*ReturnShipmentInfo  `json:"return_shipment_info,omitempty"`
+	AcceptClaimType       AcceptClaimType        `json:"accept_claim_type,omitempty"`
+}
+
+type ReturnShipmentInfo struct {
+	ShipmentLabel *ShipmentLabel `json:"shipment_label"`
+	TrackingInfo  *TrackingInfo  `json:"tracking_info"`
+}
+
+type ShipmentLabel struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type TrackingInfo struct {
+	CarrierName      string `json:"carrier_name,omitempty"`
+	TrackingNumber   string `json:"tracking_number,omitempty"`
+	CarrierNameOther string `json:"carrier_name_other,omitempty"`
+	TrackingUrl      string `json:"tracking_url,omitempty"`
+}
+
+type ReturnShippingAddress struct {
+	AddressLine1 string `json:"address_line_1,omitempty"`
+	AddressLine2 string `json:"address_line_2,omitempty"`
+	CountryCode  string `json:"country_code,omitempty"`
+	AdminArea1   string `json:"admin_area_1,omitempty"`
+	AdminArea2   string `json:"admin_area_2,omitempty"`
+	PostalCode   string `json:"postal_code,omitempty"`
+}
+
+type DisputeMakeOfferParams struct {
+	Note                  string                 `json:"note,omitempty"`
+	InvoiceId             string                 `json:"invoice_id,omitempty"`
+	OfferAmount           *Money                 `json:"offer_amount,omitempty"`
+	ReturnShippingAddress *ReturnShippingAddress `json:"return_shipping_address,omitempty"`
+	OfferType             MakeOfferType          `json:"offer_type,omitempty"`
+}
+
+type DisputeAcknowledgeReturnItemParams struct {
+	Note      string             `json:"note,omitempty"`
+	Evidences []*DisputeEvidence `json:"evidences,omitempty"`
+}
+
+type DisputeEvidence struct {
+	EvidenceType EvidenceType         `json:"evidence_type,omitempty"`
+	Documents    []*Document          `json:"documents,omitempty"`
+	Notes        string               `json:"notes,omitempty"`
+	ItemId       string               `json:"item_id,omitempty"`
+	EvidenceInfo *DisputeEvidenceInfo `json:"evidence_info,omitempty"`
+}
+
+type DisputeEvidenceInfo struct {
+	TrackingInfo []*TrackingInfo `json:"tracking_info,omitempty"`
+	RefundIds    []string        `json:"refund_ids,omitempty"`
+}
+
+type DisputeProvideEvidenceParams struct {
+	Evidences             *DisputeEvidence       `json:"evidences,omitempty"`
+	ReturnShippingAddress *ReturnShippingAddress `json:"return_shipping_address,omitempty"`
+}
+
+type DisputeAppealParams struct {
+	Evidences             *DisputeEvidence       `json:"evidences,omitempty"`
+	ReturnShippingAddress *ReturnShippingAddress `json:"return_shipping_address,omitempty"`
+}
+
 // https://developer.paypal.com/docs/api/customer-disputes/v1/#definition-dispute_info
 type DisputeState string
 
 const (
-	DisputeStateOpenInquiries            DisputeState = "OPEN_INQUIRIES"              //The dispute is open.
-	DisputeStateRequiredAction           DisputeState = "REQUIRED_ACTION"             //The dispute is waiting for a response.
-	DisputeStateRequiredOtherPartyAction DisputeState = "REQUIRED_OTHER_PARTY_ACTION" //The dispute is waiting for a response from other party.
-	DisputeStateUnderPaypalReview        DisputeState = "UNDER_PAYPAL_REVIEW"         //The dispute is under review with PayPal.
-	DisputeStateAppealable               DisputeState = "APPEALABLE"                  //The dispute can be appealed.
-	DisputeStateResolved                 DisputeState = "RESOLVED"                    //The dispute is resolved.
+	DisputeStateOpenInquiries            DisputeState = "OPEN_INQUIRIES"
+	DisputeStateRequiredAction           DisputeState = "REQUIRED_ACTION"
+	DisputeStateRequiredOtherPartyAction DisputeState = "REQUIRED_OTHER_PARTY_ACTION"
+	DisputeStateUnderPaypalReview        DisputeState = "UNDER_PAYPAL_REVIEW"
+	DisputeStateAppealable               DisputeState = "APPEALABLE"
+	DisputeStateResolved                 DisputeState = "RESOLVED"
 )
 
 type AcceptClaimReason string
 
 const (
-	AcceptClaimReasonDidNotShipItem   AcceptClaimReason = "DID_NOT_SHIP_ITEM"  //Merchant is accepting customer's claim as they could not ship the item back to the customer
-	AcceptClaimReasonTooTimeConsuming AcceptClaimReason = "TOO_TIME_CONSUMING" //Merchant is accepting customer's claim as it is taking too long for merchant to fulfil the order
-	AcceptClaimReasonLostInMail       AcceptClaimReason = "LOST_IN_MAIL"       //Merchant is accepting customer's claim as the item is lost in mail or transit
-	AcceptClaimReasonNotAbleToWin     AcceptClaimReason = "NOT_ABLE_TO_WIN"    //Merchant is accepting customer's claim as the merchant is not able to find sufficient evidence to win this dispute
-	AcceptClaimReasonCompanyPolicy    AcceptClaimReason = "COMPANY_POLICY"     //Merchant is accepting customer’s claims to follow their internal company policy
-	AcceptClaimReasonReasonNotSet     AcceptClaimReason = "REASON_NOT_SET"     //This is the default value merchant can use if none of the above reasons apply
+	AcceptClaimReasonDidNotShipItem   AcceptClaimReason = "DID_NOT_SHIP_ITEM"
+	AcceptClaimReasonTooTimeConsuming AcceptClaimReason = "TOO_TIME_CONSUMING"
+	AcceptClaimReasonLostInMail       AcceptClaimReason = "LOST_IN_MAIL"
+	AcceptClaimReasonNotAbleToWin     AcceptClaimReason = "NOT_ABLE_TO_WIN"
+	AcceptClaimReasonCompanyPolicy    AcceptClaimReason = "COMPANY_POLICY"
+	AcceptClaimReasonReasonNotSet     AcceptClaimReason = "REASON_NOT_SET"
 )
 
 type AcceptClaimType string
 
 const (
-	AcceptClaimTypeRefund                        AcceptClaimType = "REFUND"                            //	The merchant must refund the customer without any item replacement or return. This type is applicable when a merchant is willing to refund the entire dispute amount without any further action from customer. Omit the refund_amount and return_shipping_address parameters from the accept claim call.
-	AcceptClaimTypeRefundWithReturn              AcceptClaimType = "REFUND_WITH_RETURN"                //	The customer must return the item to the merchant and then merchant will refund the money. This type is applicable when a merchant is willing to refund the dispute amount and requires the customer to return the item. Include the return_shipping_address parameter in but omit the refund_amount parameter from the accept claim call.
-	AcceptClaimTypePartialRefund                 AcceptClaimType = "PARTIAL_REFUND"                    //	The merchant proposes a partial refund for the dispute.This type is applicable when a merchant is willing to refund an amount lesser than dispute amount. Include the refund_amount parameter.
-	AcceptClaimTypeRefundWithReturnShipmentLabel AcceptClaimType = "REFUND_WITH_RETURN_SHIPMENT_LABEL" //	The customer must return the item to the merchant and then merchant will refund the money. This type is applicable when a merchant is willing to refund the dispute amount and requires the customer to return the item using the shipment label provided by the merchant. Include the return_shipment_info and return_shipping_address parameter in but omit the refund_amount parameter from the accept claim call.
+	AcceptClaimTypeRefund                        AcceptClaimType = "REFUND"
+	AcceptClaimTypeRefundWithReturn              AcceptClaimType = "REFUND_WITH_RETURN"
+	AcceptClaimTypePartialRefund                 AcceptClaimType = "PARTIAL_REFUND"
+	AcceptClaimTypeRefundWithReturnShipmentLabel AcceptClaimType = "REFUND_WITH_RETURN_SHIPMENT_LABEL"
 )
 
 type AdjudicationOutcome string
 
 const (
-	AdjudicationOutcomeBuyerFavor  AdjudicationOutcome = "BUYER_FAVOR"  //	Resolves the case in the customer's favor. Outcome is set to RESOLVED_BUYER_FAVOR.
-	AdjudicationOutcomeSellerFavor AdjudicationOutcome = "SELLER_FAVOR" //	Resolves the case in the merchant's favor. Outcome is set to RESOLVED_SELLER_FAVOR.
+	AdjudicationOutcomeBuyerFavor  AdjudicationOutcome = "BUYER_FAVOR"
+	AdjudicationOutcomeSellerFavor AdjudicationOutcome = "SELLER_FAVOR"
 )
 
 type DisputeStatusAction string
 
 const (
-	DisputeStatusBuyerEvidence  DisputeStatusAction = "BUYER_EVIDENCE"  //	Changes the status of the dispute to WAITING_FOR_BUYER_RESPONSE.
-	DisputeStatusSellerEvidence DisputeStatusAction = "SELLER_EVIDENCE" //	Changes the status of the dispute to WAITING_FOR_SELLER_RESPONSE.
+	DisputeStatusBuyerEvidence  DisputeStatusAction = "BUYER_EVIDENCE"
+	DisputeStatusSellerEvidence DisputeStatusAction = "SELLER_EVIDENCE"
 )
 
 type DisputeStatus string
 
 const (
-	DisputeStatusOpen                     DisputeStatus = "OPEN"                        //	The dispute is open.
-	DisputeStatusWaitingForBuyerResponse  DisputeStatus = "WAITING_FOR_BUYER_RESPONSE"  //	The dispute is waiting for a response from the customer.
-	DisputeStatusWaitingForSellerResponse DisputeStatus = "WAITING_FOR_SELLER_RESPONSE" //	The dispute is waiting for a response from the merchant.
-	DisputeStatusUnderReview              DisputeStatus = "UNDER_REVIEW"                //	The dispute is under review with PayPal.
-	DisputeStatusResolved                 DisputeStatus = "RESOLVED"                    //	The dispute is resolved.
-	DisputeStatusOther                    DisputeStatus = "OTHER"                       //	The default status if the dispute does not have one of the other statuses.
+	DisputeStatusOpen                     DisputeStatus = "OPEN"
+	DisputeStatusWaitingForBuyerResponse  DisputeStatus = "WAITING_FOR_BUYER_RESPONSE"
+	DisputeStatusWaitingForSellerResponse DisputeStatus = "WAITING_FOR_SELLER_RESPONSE"
+	DisputeStatusUnderReview              DisputeStatus = "UNDER_REVIEW"
+	DisputeStatusResolved                 DisputeStatus = "RESOLVED"
+	DisputeStatusOther                    DisputeStatus = "OTHER"
 )
 
 type MakeOfferType string
 
 const (
-	MakeOfferTypeRefund                   MakeOfferType = "REFUND"                     //	The merchant must refund the customer without any item replacement or return. This offer type is valid in the inquiry phase and occurs when a merchant is willing to refund a specific amount. Buyer acceptance is needed for partial refund offers and dispute is auto closed for full refunds. Include the offer_amount but omit the return_shipping_address parameters from the make offer request.
-	MakeOfferTypeRefundWithReturn         MakeOfferType = "REFUND_WITH_RETURN"         //	The customer must return the item to the merchant and then merchant will refund the money. This offer type is valid in the inquiry phase and occurs when a merchant is willing to refund a specific amount and requires the customer to return the item. Include the return_shipping_address parameter and the offer_amount parameter in the make offer request.
-	MakeOfferTypeRefundWithReplacement    MakeOfferType = "REFUND_WITH_REPLACEMENT"    //	The merchant must do a refund and then send a replacement item to the customer. This offer type is valid in the inquiry phase when a merchant is willing to refund a specific amount and send the replacement item. Include the offer_amount parameter in the make offer request.
-	MakeOfferTypeReplacementWithoutRefund MakeOfferType = "REPLACEMENT_WITHOUT_REFUND" //	The merchant must send a replacement item to the customer with no additional refunds. This offer type is valid in the inquiry phase when a merchant is willing to replace the item without any refund. Omit the offer_amount parameter from the make offer request.
+	MakeOfferTypeRefund                   MakeOfferType = "REFUND"
+	MakeOfferTypeRefundWithReturn         MakeOfferType = "REFUND_WITH_RETURN"
+	MakeOfferTypeRefundWithReplacement    MakeOfferType = "REFUND_WITH_REPLACEMENT"
+	MakeOfferTypeReplacementWithoutRefund MakeOfferType = "REPLACEMENT_WITHOUT_REFUND"
 )
 
 type AcknowledgementType string
 
 const (
-	AcknowledgementTypeItemReceived            AcknowledgementType = "ITEM_RECEIVED"              //	The merchant must refund the customer without any item replacement or return. This offer type is valid in the inquiry phase and occurs when a merchant is willing to refund a specific amount. Buyer acceptance is needed for partial refund offers and dispute is auto closed for full refunds. Include the offer_amount but omit the return_shipping_address parameters from the make offer request.
-	AcknowledgementTypeItemNotReceived         AcknowledgementType = "ITEM_NOT_RECEIVED"          //	The merchant has not received the item.
-	AcknowledgementTypeDamaged                 AcknowledgementType = "DAMAGED"                    //	The items returned by the customer were damaged.
-	AcknowledgementTypeEmptyPackageOrDifferent AcknowledgementType = "EMPTY_PACKAGE_OR_DIFFERENT" //	The package was empty or the goods were different from what was expected.
-	AcknowledgementTypeMissingItems            AcknowledgementType = "MISSING_ITEMS"              //	The package did not have all the items that were expected.
+	AcknowledgementTypeItemReceived            AcknowledgementType = "ITEM_RECEIVED"
+	AcknowledgementTypeItemNotReceived         AcknowledgementType = "ITEM_NOT_RECEIVED"
+	AcknowledgementTypeDamaged                 AcknowledgementType = "DAMAGED"
+	AcknowledgementTypeEmptyPackageOrDifferent AcknowledgementType = "EMPTY_PACKAGE_OR_DIFFERENT"
+	AcknowledgementTypeMissingItems            AcknowledgementType = "MISSING_ITEMS"
 )
 
 type EvidenceType string
 
 const (
-	EvidenceTypeProofOfDamage                                   EvidenceType = "PROOF_OF_DAMAGE"                                       //	Documentation supporting the claim that the item is damaged.
-	EvidenceTypeThirdpartyProofForDamageOrSignificantDifference EvidenceType = "THIRDPARTY_PROOF_FOR_DAMAGE_OR_SIGNIFICANT_DIFFERENCE" //	Proof should be provided by an unbiased third-party, such as a dealer, appraiser or another individual or organisation that's qualified in the area of the item in question (other than yourself), and detail the extent of the damage or clearly explain how the item received significantly differs from the item advertised.
-	EvidenceTypeDelcaration                                     EvidenceType = "DECLARATION"                                           //	Signed declaration about the information provided.
-	EvidenceTypeProofOfMissingItems                             EvidenceType = "PROOF_OF_MISSING_ITEMS"                                //	Image of open box with returned items and shipping label clearly visible.
-	EvidenceTypeProofOfEmptyPackageOrDifferentItem              EvidenceType = "PROOF_OF_EMPTY_PACKAGE_OR_DIFFERENT_ITEM"              //	Image of empty box or returned items that are different from what were expected and shipping label clearly visible.
-	EvidenceTypeProofOfItemNotReceived                          EvidenceType = "PROOF_OF_ITEM_NOT_RECEIVED"                            //	Any proof about the non receipt of the item, such as screenshot of tracking info.
-	EvidenceTypeProofOfFulfillment                              EvidenceType = "PROOF_OF_FULFILLMENT"                                  //	Proof of fulfillment should be a copy of the actual shipping label on the package that shows the destination address and the shipping company's stamp to verify the shipment date.
-	EvidenceTypeProofOfRefund                                   EvidenceType = "PROOF_OF_REFUND"                                       //	Proof of refund issued to the buyer
-	EvidenceTypeProofOfDeliverySignature                        EvidenceType = "PROOF_OF_DELIVERY_SIGNATURE"                           //	Proof of delivery signature.
-	EvidenceTypeProofOfReceiptCopy                              EvidenceType = "PROOF_OF_RECEIPT_COPY"                                 //	Copy of original receipt or invoice.
-	EvidenceTypeReturnPolicy                                    EvidenceType = "RETURN_POLICY"                                         //	Copy of terms and conditions,contract or store return policy
-	EvidenceTypeBillingAgreement                                EvidenceType = "BILLING_AGREEMENT"                                     //	Copy of billing agreement.
-	EvidenceTypeProofOfReshipment                               EvidenceType = "PROOF_OF_RESHIPMENT"                                   //	Proof of reshipment should be a copy of the actual shipping label on the package that shows the destination address and the shipping company's stamp to verify the reshipment date.
-	EvidenceTypeItemDescription                                 EvidenceType = "ITEM_DESCRIPTION"                                      //	A copy of the original description of the item or service
-	EvidenceTypePoliceReport                                    EvidenceType = "POLICE_REPORT"                                         //	Copy of the police report filed.
-	EvidenceTypeAffidavit                                       EvidenceType = "AFFIDAVIT"                                             //	More information has to be provided about the claim using the affidavit.
-	EvidenceTypePaidWithOtherMethod                             EvidenceType = "PAID_WITH_OTHER_METHOD"                                //	Document showing item/service was paid by another payment method.
-	EvidenceTypeCopyOfContract                                  EvidenceType = "COPY_OF_CONTRACT"                                      //	Copy of contract if applicable.
-	EvidenceTypeTerminalAtmReceipt                              EvidenceType = "TERMINAL_ATM_RECEIPT"                                  //	Copy of terminal/ATM receipt.
-	EvidenceTypePriceDifferenceReason                           EvidenceType = "PRICE_DIFFERENCE_REASON"                               //	Explanation of what the price difference is related to (increased tip amount, shipping charges, taxes, etc).
-	EvidenceTypeSourceConversionRate                            EvidenceType = "SOURCE_CONVERSION_RATE"                                //	Source of expected conversion rate or fee.
-	EvidenceTypeBankStatement                                   EvidenceType = "BANK_STATEMENT"                                        //	Bank/Credit statement showing withdrawal transaction.
-	EvidenceTypeCreditDueReason                                 EvidenceType = "CREDIT_DUE_REASON"                                     //	The credit due reason.
-	EvidenceTypeRequestCreditReceipt                            EvidenceType = "REQUEST_CREDIT_RECEIPT"                                //	The request credit receipt.
-	EvidenceTypeProofOfReturn                                   EvidenceType = "PROOF_OF_RETURN"                                       //	Proof of shipment or postage that shows you returned this item to your seller and should be a copy of the actual shipping label used.
-	EvidenceTypeCreate                                          EvidenceType = "CREATE"                                                //	Additional evidence information during case creation.
-	EvidenceTypeChangeReason                                    EvidenceType = "CHANGE_REASON"                                         //	The evidence related to the reason change.
-	EvidenceTypeProofOfRefundOutsidePaypa                       EvidenceType = "PROOF_OF_REFUND_OUTSIDE_PAYPA"                         //L	Document should show that the seller issued a refund outside Paypal.
-	EvidenceTypeReceiptOfMerchandise                            EvidenceType = "RECEIPT_OF_MERCHANDISE"                                //	Check with buyer if item Delivered (seller provided Proof of Shipping)
-	EvidenceTypeCustomsDocument                                 EvidenceType = "CUSTOMS_DOCUMENT"                                      //	Document confirming that the item has been confiscated.
-	EvidenceTypeCustomsFeeReceipt                               EvidenceType = "CUSTOMS_FEE_RECEIPT"                                   //	Custom fees receipt paid by the buyer
-	EvidenceTypeInformationOnResolution                         EvidenceType = "INFORMATION_ON_RESOLUTION"                             //	Any resolution reached with the seller should be communicated to PayPal.
-	EvidenceTypeAdditionalInformationOfItem                     EvidenceType = "ADDITIONAL_INFORMATION_OF_ITEM"                        //	Any additional information of the item purchased.
-	EvidenceTypeDetailsOfPurchase                               EvidenceType = "DETAILS_OF_PURCHASE"                                   //	Specific details of a purchase made under a particular transaction has to be given.
-	EvidenceTypeProofOfSignificantDifference                    EvidenceType = "PROOF_OF_SIGNIFICANT_DIFFERENCE"                       //	More information required on how the item was damaged or was significantly different from the item advertised.
-	EvidenceTypeProofOfSoftwareOrServiceNotAsDescribed          EvidenceType = "PROOF_OF_SOFTWARE_OR_SERVICE_NOT_AS_DESCRIBED"         //	Any screenshot or download/usage log showing that the software or service was unavailable or non-functional.
-	EvidenceTypeProofOfConfiscation                             EvidenceType = "PROOF_OF_CONFISCATION	Documentation"                   // from a third party or organization that evaluated this item that confirms they confiscated it.
-	EvidenceTypeCopyOfLawEnforcementAgencyReport                EvidenceType = "COPY_OF_LAW_ENFORCEMENT_AGENCY_REPORT"                 //	Report filed with a law enforcement agency or government organization. Examples of such agencies are - Internet Crime Complaint Center (www.ic3.gov), state Consumer Protection office, state police or a Federal law enforcement agency such as the FBI or Postal Inspection Service.
-	EvidenceTypeAdditionalProofOfShipment                       EvidenceType = "ADDITIONAL_PROOF_OF_SHIPMENT"                          //	Additional proof of shipment such as a packing list, detailed invoice, or shipping manifest to confirm that all items have been shipped. Include carrier name and tracking number if available.
-	EvidenceTypeProofOfDenialByCarrier                          EvidenceType = "PROOF_OF_DENIAL_BY_CARRIER"                            //	Documentation from the carrier should confirm the reason why they refuse to ship the item in question and the extent of the original damage.
-	EvidenceTypeValidSupportingDocument                         EvidenceType = "VALID_SUPPORTING_DOCUMENT"                             //	The document you have provided doesn't support your claim that the item is Significantly Not as Described. Please provide a document to clearly show how the item received significantly differs from the item advertised.
-	EvidenceTypeLegibleSupportingDocument                       EvidenceType = "LEGIBLE_SUPPORTING_DOCUMENT"                           //	The document you have provided is illegible, unclear, or too dark to read. Please provide a document that is legible and clear to read.
-	EvidenceTypeReturnTrackingInformation                       EvidenceType = "RETURN_TRACKING_INFORMATION"                           //	Online tracking information for remaining items that have to be shipped to the seller.
-	EvidenceTypeDeliveryReceipt                                 EvidenceType = "DELIVERY_RECEIPT"                                      //	Confirmation that the item has been received.
-	EvidenceTypeProofOfInstoreReceipt                           EvidenceType = "PROOF_OF_INSTORE_RECEIPT"                              //	In-store receipt or online verification should clearly show that the buyer picked up the item.
-	EvidenceTypeAdditionalTrackingInformation                   EvidenceType = "ADDITIONAL_TRACKING_INFORMATION"                       //	Tracking information should include the carrier name, online tracking number and the website where the shipment can be tracked.
-	EvidenceTypeProofOfShipmentPostage                          EvidenceType = "PROOF_OF_SHIPMENT_POSTAGE"                             //	Proof of shipment or postage should be a copy of the actual shipping label on the package that shows the destination address and the carrier's stamp to verify the shipment date.
-	EvidenceTypeOnlineTrackingInformation                       EvidenceType = "ONLINE_TRACKING_INFORMATION"                           //	Online tracking information to confirm delivery of item.
-	EvidenceTypeProofOfInstoreRefund                            EvidenceType = "PROOF_OF_INSTORE_REFUND"                               //	Proof should be an in-store refund receipt or company documentation that clearly shows a completed refund for the transaction.
-	EvidenceTypeProofForSoftwareOrServiceDelivered              EvidenceType = "PROOF_FOR_SOFTWARE_OR_SERVICE_DELIVERED"               //	Proof should be compelling evidence to prove that the item or service was as described and was delivered to the buyer. Include information such as transaction ID, invoice ID, name or email to associate the evidence with the buyer along with date and time of the delivery.
-	EvidenceTypeReturnAddressForShipping                        EvidenceType = "RETURN_ADDRESS_FOR_SHIPPING"                           //	Return address is required for the buyer to ship the merchandise back to the seller.
-	EvidenceTypeCopyOfTheEparcelManifest                        EvidenceType = "COPY_OF_THE_EPARCEL_MANIFEST"                          //	To validate a claim, a copy of the eparcel manifest showing the buyer's address from Australia Post is required.
-	EvidenceTypeCopyOfShippingManifest                          EvidenceType = "COPY_OF_SHIPPING_MANIFEST"                             //	The shipping manifest must show the buyer's address and can be obtained from the carrier.
-	EvidenceTypeAppealAffidavit                                 EvidenceType = "APPEAL_AFFIDAVIT"                                      //	Appeal affidavit is needed to make an appeal for any case outcome.
-	EvidenceTypeReceiptOfReplacement                            EvidenceType = "RECEIPT_OF_REPLACEMENT"                                //	Check with buyer if the replacement of the item sent by the seller was received
-	EvidenceTypeCopyOfDriversLicense                            EvidenceType = "COPY_OF_DRIVERS_LICENSE"                               //	Need Copy of Drivers license.
-	EvidenceTypeAccountChangeInformation                        EvidenceType = "ACCOUNT_CHANGE_INFORMATION"                            //	Additional Details about how account was accessed/what was changed.
-	EvidenceTypeDeliveryAddress                                 EvidenceType = "DELIVERY_ADDRESS"                                      //	Address where item was supposed to be delivered.
-	EvidenceTypeConfirmationOfResolution                        EvidenceType = "CONFIRMATION_OF_RESOLUTION"                            //	Confirmation that item was received and issue resolved.
-	EvidenceTypeMerchantResponse                                EvidenceType = "MERCHANT_RESPONSE"                                     //	Copy of merchant's response when the resolution was attempted.
-	EvidenceTypePermissionDescription                           EvidenceType = "PERMISSION_DESCRIPTION"                                //	A Detailed description about the account or card level permission given to another person.
-	EvidenceTypeStatusOfMerchandise                             EvidenceType = "STATUS_OF_MERCHANDISE"                                 //	Details of the merchandise's current location.
-	EvidenceTypeLostCardDetails                                 EvidenceType = "LOST_CARD_DETAILS"                                     //	Details of where and when the card was lost/stolen?.
-	EvidenceTypeLastValidTransactionDetails                     EvidenceType = "LAST_VALID_TRANSACTION_DETAILS"                        //	Details of the last valid transaction made on the card.
-	EvidenceTypeAdditionalProofOfReturn                         EvidenceType = "ADDITIONAL_PROOF_OF_RETURN"                            //	Document to confirm that the item to be returned to the seller has been shipped.
-	EvidenceTypeOrderDetails                                    EvidenceType = "ORDER_DETAILS"                                         //	Order details or photos of the item/service/booking/digital download available on the website.
-	EvidenceTypeListingUrl                                      EvidenceType = "LISTING_URL"                                           //	The website URLs of the item/service/booking/digital download.
-	EvidenceTypeShippingInsurance                               EvidenceType = "SHIPPING_INSURANCE"                                    //	Insurance information of the shipped item.
-	EvidenceTypeBuyerResponse                                   EvidenceType = "BUYER_RESPONSE"                                        //	Copy of the buyer response or any other document showing buyer's understanding of the item/service/booking/digital download purchased.
-	EvidenceTypePhotosOfShippedItem                             EvidenceType = "PHOTOS_OF_SHIPPED_ITEM"                                //	Photos of the item that were shipped to the buyer.
-	EvidenceTypeOther                                           EvidenceType = "OTHER"                                                 //	Other.
-	EvidenceTypeCancellationDetails                             EvidenceType = "CANCELLATION_DETAILS"                                  //	Cancellation details information, for example- cancellation date, cancellation number.
-	EvidenceTypeMerchantContactDetails                          EvidenceType = "MERCHANT_CONTACT_DETAILS"                              //	Merchant contacted details information, for example- merchant contacted time, mode of contacting.
-	EvidenceTypeItemDetails                                     EvidenceType = "ITEM_DETAILS"                                          //	Item related details information, for example- expected delivery date.
-	EvidenceTypeCorrectRecipientInformation                     EvidenceType = "CORRECT_RECIPIENT_INFORMATION"                         //	Proof of the correct recipient name, email or phone.
-	EvidenceTypeExplanationOfFundsNotDelivered                  EvidenceType = "EXPLANATION_OF_FUNDS_NOT_DELIVERED"                    //	Details on why the funds were not delivered to the correct recipient.
+	EvidenceTypeProofOfDamage                                   EvidenceType = "PROOF_OF_DAMAGE"
+	EvidenceTypeThirdpartyProofForDamageOrSignificantDifference EvidenceType = "THIRDPARTY_PROOF_FOR_DAMAGE_OR_SIGNIFICANT_DIFFERENCE"
+	EvidenceTypeDelcaration                                     EvidenceType = "DECLARATION"
+	EvidenceTypeProofOfMissingItems                             EvidenceType = "PROOF_OF_MISSING_ITEMS"
+	EvidenceTypeProofOfEmptyPackageOrDifferentItem              EvidenceType = "PROOF_OF_EMPTY_PACKAGE_OR_DIFFERENT_ITEM"
+	EvidenceTypeProofOfItemNotReceived                          EvidenceType = "PROOF_OF_ITEM_NOT_RECEIVED"
+	EvidenceTypeProofOfFulfillment                              EvidenceType = "PROOF_OF_FULFILLMENT"
+	EvidenceTypeProofOfRefund                                   EvidenceType = "PROOF_OF_REFUND"
+	EvidenceTypeProofOfDeliverySignature                        EvidenceType = "PROOF_OF_DELIVERY_SIGNATURE"
+	EvidenceTypeProofOfReceiptCopy                              EvidenceType = "PROOF_OF_RECEIPT_COPY"
+	EvidenceTypeReturnPolicy                                    EvidenceType = "RETURN_POLICY"
+	EvidenceTypeBillingAgreement                                EvidenceType = "BILLING_AGREEMENT"
+	EvidenceTypeProofOfReshipment                               EvidenceType = "PROOF_OF_RESHIPMENT"
+	EvidenceTypeItemDescription                                 EvidenceType = "ITEM_DESCRIPTION"
+	EvidenceTypePoliceReport                                    EvidenceType = "POLICE_REPORT"
+	EvidenceTypeAffidavit                                       EvidenceType = "AFFIDAVIT"
+	EvidenceTypePaidWithOtherMethod                             EvidenceType = "PAID_WITH_OTHER_METHOD"
+	EvidenceTypeCopyOfContract                                  EvidenceType = "COPY_OF_CONTRACT"
+	EvidenceTypeTerminalAtmReceipt                              EvidenceType = "TERMINAL_ATM_RECEIPT"
+	EvidenceTypePriceDifferenceReason                           EvidenceType = "PRICE_DIFFERENCE_REASON"
+	EvidenceTypeSourceConversionRate                            EvidenceType = "SOURCE_CONVERSION_RATE"
+	EvidenceTypeBankStatement                                   EvidenceType = "BANK_STATEMENT"
+	EvidenceTypeCreditDueReason                                 EvidenceType = "CREDIT_DUE_REASON"
+	EvidenceTypeRequestCreditReceipt                            EvidenceType = "REQUEST_CREDIT_RECEIPT"
+	EvidenceTypeProofOfReturn                                   EvidenceType = "PROOF_OF_RETURN"
+	EvidenceTypeCreate                                          EvidenceType = "CREATE"
+	EvidenceTypeChangeReason                                    EvidenceType = "CHANGE_REASON"
+	EvidenceTypeProofOfRefundOutsidePaypa                       EvidenceType = "PROOF_OF_REFUND_OUTSIDE_PAYPA"
+	EvidenceTypeReceiptOfMerchandise                            EvidenceType = "RECEIPT_OF_MERCHANDISE"
+	EvidenceTypeCustomsDocument                                 EvidenceType = "CUSTOMS_DOCUMENT"
+	EvidenceTypeCustomsFeeReceipt                               EvidenceType = "CUSTOMS_FEE_RECEIPT"
+	EvidenceTypeInformationOnResolution                         EvidenceType = "INFORMATION_ON_RESOLUTION"
+	EvidenceTypeAdditionalInformationOfItem                     EvidenceType = "ADDITIONAL_INFORMATION_OF_ITEM"
+	EvidenceTypeDetailsOfPurchase                               EvidenceType = "DETAILS_OF_PURCHASE"
+	EvidenceTypeProofOfSignificantDifference                    EvidenceType = "PROOF_OF_SIGNIFICANT_DIFFERENCE"
+	EvidenceTypeProofOfSoftwareOrServiceNotAsDescribed          EvidenceType = "PROOF_OF_SOFTWARE_OR_SERVICE_NOT_AS_DESCRIBED"
+	EvidenceTypeProofOfConfiscation                             EvidenceType = "PROOF_OF_CONFISCATION	Documentation"
+	EvidenceTypeCopyOfLawEnforcementAgencyReport                EvidenceType = "COPY_OF_LAW_ENFORCEMENT_AGENCY_REPORT"
+	EvidenceTypeAdditionalProofOfShipment                       EvidenceType = "ADDITIONAL_PROOF_OF_SHIPMENT"
+	EvidenceTypeProofOfDenialByCarrier                          EvidenceType = "PROOF_OF_DENIAL_BY_CARRIER"
+	EvidenceTypeValidSupportingDocument                         EvidenceType = "VALID_SUPPORTING_DOCUMENT"
+	EvidenceTypeLegibleSupportingDocument                       EvidenceType = "LEGIBLE_SUPPORTING_DOCUMENT"
+	EvidenceTypeReturnTrackingInformation                       EvidenceType = "RETURN_TRACKING_INFORMATION"
+	EvidenceTypeDeliveryReceipt                                 EvidenceType = "DELIVERY_RECEIPT"
+	EvidenceTypeProofOfInstoreReceipt                           EvidenceType = "PROOF_OF_INSTORE_RECEIPT"
+	EvidenceTypeAdditionalTrackingInformation                   EvidenceType = "ADDITIONAL_TRACKING_INFORMATION"
+	EvidenceTypeProofOfShipmentPostage                          EvidenceType = "PROOF_OF_SHIPMENT_POSTAGE"
+	EvidenceTypeOnlineTrackingInformation                       EvidenceType = "ONLINE_TRACKING_INFORMATION"
+	EvidenceTypeProofOfInstoreRefund                            EvidenceType = "PROOF_OF_INSTORE_REFUND"
+	EvidenceTypeProofForSoftwareOrServiceDelivered              EvidenceType = "PROOF_FOR_SOFTWARE_OR_SERVICE_DELIVERED"
+	EvidenceTypeReturnAddressForShipping                        EvidenceType = "RETURN_ADDRESS_FOR_SHIPPING"
+	EvidenceTypeCopyOfTheEparcelManifest                        EvidenceType = "COPY_OF_THE_EPARCEL_MANIFEST"
+	EvidenceTypeCopyOfShippingManifest                          EvidenceType = "COPY_OF_SHIPPING_MANIFEST"
+	EvidenceTypeAppealAffidavit                                 EvidenceType = "APPEAL_AFFIDAVIT"
+	EvidenceTypeReceiptOfReplacement                            EvidenceType = "RECEIPT_OF_REPLACEMENT"
+	EvidenceTypeCopyOfDriversLicense                            EvidenceType = "COPY_OF_DRIVERS_LICENSE"
+	EvidenceTypeAccountChangeInformation                        EvidenceType = "ACCOUNT_CHANGE_INFORMATION"
+	EvidenceTypeDeliveryAddress                                 EvidenceType = "DELIVERY_ADDRESS"
+	EvidenceTypeConfirmationOfResolution                        EvidenceType = "CONFIRMATION_OF_RESOLUTION"
+	EvidenceTypeMerchantResponse                                EvidenceType = "MERCHANT_RESPONSE"
+	EvidenceTypePermissionDescription                           EvidenceType = "PERMISSION_DESCRIPTION"
+	EvidenceTypeStatusOfMerchandise                             EvidenceType = "STATUS_OF_MERCHANDISE"
+	EvidenceTypeLostCardDetails                                 EvidenceType = "LOST_CARD_DETAILS"
+	EvidenceTypeLastValidTransactionDetails                     EvidenceType = "LAST_VALID_TRANSACTION_DETAILS"
+	EvidenceTypeAdditionalProofOfReturn                         EvidenceType = "ADDITIONAL_PROOF_OF_RETURN"
+	EvidenceTypeOrderDetails                                    EvidenceType = "ORDER_DETAILS"
+	EvidenceTypeListingUrl                                      EvidenceType = "LISTING_URL"
+	EvidenceTypeShippingInsurance                               EvidenceType = "SHIPPING_INSURANCE"
+	EvidenceTypeBuyerResponse                                   EvidenceType = "BUYER_RESPONSE"
+	EvidenceTypePhotosOfShippedItem                             EvidenceType = "PHOTOS_OF_SHIPPED_ITEM"
+	EvidenceTypeOther                                           EvidenceType = "OTHER"
+	EvidenceTypeCancellationDetails                             EvidenceType = "CANCELLATION_DETAILS"
+	EvidenceTypeMerchantContactDetails                          EvidenceType = "MERCHANT_CONTACT_DETAILS"
+	EvidenceTypeItemDetails                                     EvidenceType = "ITEM_DETAILS"
+	EvidenceTypeCorrectRecipientInformation                     EvidenceType = "CORRECT_RECIPIENT_INFORMATION"
+	EvidenceTypeExplanationOfFundsNotDelivered                  EvidenceType = "EXPLANATION_OF_FUNDS_NOT_DELIVERED"
 )


### PR DESCRIPTION
This PR add paypal's 15 disputes apis.
just add two new files:dispute.go and dispute_type.go,and no other files modified.