### PR TITLE
Add PayPal STC API

### DIFF
--- a/order.go
+++ b/order.go
@@ -23,7 +23,7 @@ func (c *Client) GetOrder(ctx context.Context, orderID string) (*Order, error) {
 	return order, nil
 }
 
-// Create an order
+// CreateOrder Create an order
 // Endpoint: POST /v2/checkout/orders
 func (c *Client) CreateOrder(ctx context.Context, intent string, purchaseUnits []PurchaseUnitRequest, paymentSource *PaymentSource, appContext *ApplicationContext) (*Order, error) {
 	return c.CreateOrderWithPaypalRequestID(ctx, intent, purchaseUnits, paymentSource, appContext, "")
@@ -113,7 +113,7 @@ func (c *Client) CaptureOrder(ctx context.Context, orderID string, captureOrderR
 	return c.CaptureOrderWithPaypalRequestId(ctx, orderID, captureOrderRequest, "", nil)
 }
 
-// CaptureOrder with idempotency - https://developer.paypal.com/docs/api/orders/v2/#orders_capture
+// CaptureOrderWithPaypalRequestId with idempotency - https://developer.paypal.com/docs/api/orders/v2/#orders_capture
 // Endpoint: POST /v2/checkout/orders/ID/capture
 // https://developer.paypal.com/docs/api/reference/api-requests/#http-request-headers
 func (c *Client) CaptureOrderWithPaypalRequestId(ctx context.Context,
@@ -143,6 +143,11 @@ func (c *Client) CaptureOrderWithPaypalRequestId(ctx context.Context,
 		req.Header.Set("PayPal-Mock-Response", string(mock))
 	}
 
+	//Add for STC API, we need to link order together
+	//https://developer.paypal.com/limited-release/raas/integration-guide/#link-setthetransactioncontext
+	//https://developer.paypal.com/docs/api/orders/v2/#orders_capture!in=header&path=PayPal-Client-Metadata-Id&t=request
+	req.Header.Set("PayPal-Client-Metadata-Id", orderID)
+
 	if err = c.SendWithAuth(req, capture); err != nil {
 		return capture, err
 	}
@@ -156,7 +161,7 @@ func (c *Client) RefundCapture(ctx context.Context, captureID string, refundCapt
 	return c.RefundCaptureWithPaypalRequestId(ctx, captureID, refundCaptureRequest, "")
 }
 
-// RefundCapture with idempotency - https://developer.paypal.com/docs/api/payments/v2/#captures_refund
+// RefundCaptureWithPaypalRequestId with idempotency - https://developer.paypal.com/docs/api/payments/v2/#captures_refund
 // Endpoint: POST /v2/payments/captures/ID/refund
 func (c *Client) RefundCaptureWithPaypalRequestId(ctx context.Context,
 	captureID string,

--- a/stc.go
+++ b/stc.go
@@ -1,0 +1,31 @@
+package paypal
+
+import (
+	"context"
+	"fmt"
+)
+
+// SetTransactionContext
+// PayPal partners and merchants can Set transaction context to send additional data about a customer to PayPal before the customer transaction is processed.
+// PayPal uses this data to complete a pre-transaction risk management evaluation
+// Endpoint: PUT <endpoint>/v1/risk/transaction-contexts/<merchant_id>/<tracking_id>
+func (c *Client) SetTransactionContext(ctx context.Context, merchantID, orderID string, tcPayload interface{}) error {
+
+	if merchantID == "" || orderID == "" {
+		return fmt.Errorf("paypal: merchantID or orderID is empty")
+	}
+
+	url := fmt.Sprintf("%s%s%s", c.APIBase, "/v1/risk/transaction-contexts/", merchantID+"/"+orderID)
+
+	req, err := c.NewRequest(ctx, "PUT", url, tcPayload)
+
+	if err != nil {
+		return err
+	}
+
+	if err = c.SendWithAuth(req, nil); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
#### What does this PR do?
Add PayPal STC API and PayPal-Client-Metadata-Id value in the Capture API call header
#### Where should the reviewer start?
Add a file "stc.go" and Line 149 in order.go
#### How should this be manually tested?

1. c.SetTransactionContext(ctx, merchantId, orderID, payload)
2. capture order like before

#### Any background context you want to provide?
I get an email from PayPal support team. They said: *Please make sure you are calling the STC API for the transaction and ensure that you are passing the same tracking ID as the PayPal-Client-Metadata-Id value in the Capture API call header.*